### PR TITLE
Typo in no-restricted-imports config

### DIFF
--- a/eslint/config/audacia-eslint-config/package.json
+++ b/eslint/config/audacia-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audacia/eslint-config",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ESLint Rules for Typescript projects.",
   "main": "index.js",
   "repository": {

--- a/eslint/config/audacia-eslint-config/rules/es6.js
+++ b/eslint/config/audacia-eslint-config/rules/es6.js
@@ -4,7 +4,7 @@ module.exports = {
     // disallow specific imports
     // https://eslint.org/docs/rules/no-restricted-imports
     'no-restricted-imports': 'off',
-    '@typecript-eslint/no-restricted-imports': ['error', {
+    '@typescript-eslint/no-restricted-imports': ['error', {
       paths: ['rxjs', 'lodash'],
       patterns: []
     }]


### PR DESCRIPTION
Was giving an error in IDE as the rule could not be found due to the typo:
![image](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/assets/75783565/a5dad983-c9db-4bad-a8b2-011edcaaef51)


| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ❌ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ❌ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |