### PR TITLE
Update Peer Deps ranges

### DIFF
--- a/eslint/config/audacia-eslint-config/package.json
+++ b/eslint/config/audacia-eslint-config/package.json
@@ -10,10 +10,10 @@
   "author": "Audacia",
   "license": "ISC",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "5.13.0",
-    "@typescript-eslint/parser": "5.0.0",
-    "eslint": "7.32.0 || 8.2.0",
-    "eslint-plugin-import": "2.25.3"
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^7.0.0 || ^8.0.0",
+    "eslint-plugin-import": "^2.25.0"
   },
   "dependencies": {
     "eslint-config-airbnb-typescript": "17.0.0"

--- a/eslint/config/audacia-eslint-config/package.json
+++ b/eslint/config/audacia-eslint-config/package.json
@@ -10,10 +10,10 @@
   "author": "Audacia",
   "license": "ISC",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.0.0",
-    "eslint": "^7.0.0 || ^8.0.0",
-    "eslint-plugin-import": "^2.25.0"
+    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint-plugin-import": "^2.25.3"
   },
   "dependencies": {
     "eslint-config-airbnb-typescript": "17.0.0"

--- a/eslint/config/audacia-eslint-config/package.json
+++ b/eslint/config/audacia-eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audacia/eslint-config",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "ESLint Rules for Typescript projects.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Added the `^` to peer deps so it can support a wider range of dependencies

| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ❌ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ❌ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |