### PR TITLE
Feature/help links

### DIFF
--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -39,7 +39,7 @@ To run VS experimentally set the `.Vsix` project as the startup project, which l
 </tr>
 <tr>
     <td>Audacia coding standard:</td>
-    <td>CS-05.2:</td>
+    <td>CS-05.2</td>
 </tr>
 </table>
 

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -436,19 +436,47 @@ ACL1009 is based on CSharpGuidelinesAnalyzer [AV1551](https://github.com/dennisd
 
 ACL1009 reports warnings on the three rules below:
 
-- That an overloaded method does not call another overload (unless it is the longest in the group)
-- That the longest overloaded method (the one with the most parameters) is not virtual.
-- That the order of parameters in an overloaded method does not match with the parameter order of the longest overload.
+### That an overloaded method does not call another overload (unless it is the longest in the group)
 
 Code with diagnostic:
 
 ```csharp
 public void TestMethod(int i, string s)
 {
-    var line = string.Format(s, i, 0);
+   var line = string.Format(s, i, 0);
 }
 
-public void TestMethod(int i, string s, int j = 0)
+public virtual void TestMethod(int i, string s, int j)
+{
+   var line = string.Format(s, i, j);
+}
+```
+
+Code without diagnostic:
+
+```csharp
+public void TestMethod(int i, string s)
+{
+    TestMethod(i, s, 0);
+}
+
+public virtual void TestMethod(int i, string s, int j)
+{
+    var line = string.Format(s, i, j);
+}
+```
+
+### That the longest overloaded method (the one with the most parameters) is not virtual.
+
+Code with diagnostic:
+
+```csharp
+public void TestMethod(int i, string s)
+{
+    TestMethod(i, s, 0);
+}
+
+public void TestMethod(int i, string s, int j)
 {
     var line = string.Format(s, i, j);
 }
@@ -462,7 +490,36 @@ public void TestMethod(int i, string s)
     TestMethod(i, s, 0);
 }
 
-public virtual void TestMethod(int i, string s, int j = 0)
+public virtual void TestMethod(int i, string s, int j)
+{
+    var line = string.Format(s, i, j);
+}
+```
+### The order of parameters in an overloaded method does not match with the parameter order of the longest overload.
+
+Code with diagnostic:
+
+```csharp
+public void TestMethod(string s, int i)
+{
+    TestMethod(i, s, 0);
+}
+
+public virtual void TestMethod(int i, string s, int j)
+{
+    var line = string.Format(s, i, j);
+}
+```
+
+Code without diagnostic:
+
+```csharp
+public void TestMethod(int i, string s)
+{
+    TestMethod(i, s, 0);
+}
+
+public virtual void TestMethod(int i, string s, int j)
 {
     var line = string.Format(s, i, j);
 }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -19,6 +19,9 @@ Note the second PR is needed as `Audacia.CodeAnalysis.Analyzers` should be consu
 
 **Important:** The unit test project in this solution will fail to build if the path length of items in the bin folder exceeds 260 characters. (You will see errors similar to `Could not copy Microsoft.VisualStudio.TestPlatform.MSTestAdapter.PlatformServices.Interface.dll`). Therefore, it is recommended to clone this repo into a high-level directory (e.g. C:\Projects).
 
+## Help link URLs
+If the titles of any of the below analyzers change, ensure [HelpLinkUrlFactory](./src/Audacia.CodeAnalysis.Analyzers/Common/HelpLinkUrlFactory.cs) is updated to reflect the new titles.
+
 ## Testing changes locally
 
 **Prerequisites**: The "Visual Studio extension development" toolset is required for testing changes locally. This can be installed by modifying your installation of visual studio, and search for this toolset under the 'Other Toolsets' header.
@@ -28,6 +31,17 @@ To run VS experimentally set the `.Vsix` project as the startup project, which l
 # Analyzers
 
 ## ACL1000 - Private fields should be prefixed with an underscore
+
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Naming</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-05.2:</td>
+</tr>
+</table>
 
 The ACL1000 rule checks whether private field names are prefixed with an underscore. It also provides a code fix, which inserts an underscore.
 
@@ -51,7 +65,17 @@ public class MyClass
 
 ## ACL1001 - Variable declarations should not use a magic number
 
-Category: Usage
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Usage</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.8</td>
+</tr>
+</table>
+
 
 The ACL1001 rule checks for magic numbers being used in variable declarations. Magic numbers should generally be extracted to a well-named variable.
 
@@ -76,7 +100,16 @@ var next = previous + 1;
 
 ## ACL1002 - Methods should not exceed a predefined number of statements
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintanability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.1</td>
+</tr>
+</table>
 
 The ACL1002 rule checks the number of statements in a method (or property or constructor) against a maximum allowed value. This maximum value can be configured globally in the .editorconfig file, or locally using the `[MaxMethodLength]` attribute (this is in the `Audacia.CodeAnalysis.Analyzers.Helpers` NuGet package, which must be installed separately). In the absence of any configured value, a default maximum value of 10 is used.
 
@@ -148,7 +181,16 @@ public void MyMethod(string arg)
 
 ## ACL1003 - Don't declare signatures with more than a predefined number of parameters
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintanability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.21</td>
+</tr>
+</table>
 
 The ACL1003 rule checks the number of parameters for a method or constructor against a maximum allowed value. This maximum value can be configured globally in the .editorconfig file, or locally using the `[MaxParameterCount]` attribute (this is in the `Audacia.CodeAnalysis.Analyzers.Helpers` NuGet package, which must be installed separately). In the absence of any configured value, a default maximum value of 4 is used.
 
@@ -200,7 +242,16 @@ public async Task MyMethodAsync(int a, int b, int c, int d, CancellationToken ca
 
 ## ACL1004 - Don't use abbreviations
 
-Category: Naming
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Naming</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-05.1</td>
+</tr>
+</table>
 
 The ACL1004 rule checks whether single characters or (specific) abbreviations have been used as a type, member, parameter or variable name.
 
@@ -261,9 +312,18 @@ for (var i = 0; i < 10; i++)
 
 ## ACL1005 - Asynchronous method name is not suffixed with 'Async'
 
-Category: Naming
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Naming</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-05.15</td>
+</tr>
+</table>
 
-ACL1005 is based on the Roslynator rule [RCS1046](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1046.md), which checks if asynchronous methods are suffixed with 'Async'.
+ACL1005 is based on the Roslynator rule [RCS1046](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1046), which checks if asynchronous methods are suffixed with 'Async'.
 
 ACL1005 adds an exclusion for controller actions, as they are often asynchronous but should generally not be suffixed.
 
@@ -271,7 +331,9 @@ ACL1005 adds an exclusion for controller actions, as they are often asynchronous
 
 Category: Style
 
-ACL1006 is based on the Roslynator rule [RCS1007](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1007.md), which checks if statements such as `if`, `foreach` and `using` are followed by braces.
+Audacia coding standard: `CS-06.1`
+
+ACL1006 is based on the Roslynator rule [RCS1007](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1007), which checks if statements such as `if`, `foreach` and `using` are followed by braces.
 
 ACL1006 adds an exclusion for `if` statements performing an argument null check. For example, using ACL1006 rather than RCS1007, the following code becomes valid:
 
@@ -286,9 +348,18 @@ The justification for this exclusion is that argument null checks, while advised
 
 ## ACL1007 - ThenByDescending instead of OrderByDescending if follows OrderBy or OrderByDescending statement
 
-Category: Usage
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Usage</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>N/A</td>
+</tr>
+</table>
 
-ACL1007 is similar in function to the Roslynator rule [RCS1200](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1200.md), which checks if an `OrderBy` follows an `OrderBy` or `OrderByDescending`, and suggests using `ThenBy` instead if so.
+ACL1007 is similar in function to the Roslynator rule [RCS1200](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1200), which checks if an `OrderBy` follows an `OrderBy` or `OrderByDescending`, and suggests using `ThenBy` instead if so.
 
 ACL1007 checks if an `OrderByDescending` follows an `OrderBy` or `OrderByDescending` and suggests using `ThenByDescending` instead if so.
 
@@ -306,7 +377,16 @@ var x = items.OrderBy(f => f.Surname).ThenByDescending(f => f.Name);
 
 ## ACL1008 - Controller actions have ProducesResponseType attribute
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintainability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>N/A</td>
+</tr>
+</table>
 
 ACL1008 checks if a controller action has at least one `ProducesResponseType` attribute and will produce a warning if not.
 This applies to controller actions defined by either an Http attribute (eg. `HttpGet`) or by the parent class inheriting the `ControllerBase` class.
@@ -317,7 +397,7 @@ Code with diagnostic:
 [HttpGet]
 public string Get()
 {
-	return 'hello';
+    return 'hello';
 }
 ```
 
@@ -328,13 +408,22 @@ Code without diagnostic:
 [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
 public string Get()
 {
-	return 'hello';
+    return 'hello';
 }
 ```
 
 ## ACL1009 - Method overload should call another overload
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintainability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.20</td>
+</tr>
+</table>
 
 ACL1009 is based on CSharpGuidelinesAnalyzer [AV1551](https://github.com/dennisdoomen/CSharpGuidelines/blob/5.6.0/_rules/1551.md), which ensures the more overloaded method is called from other overloads.
 
@@ -347,14 +436,14 @@ ACL1009 reports warnings on the three rules below:
 Code with diagnostic:
 
 ```csharp
-public void TestMethod(int i, int j)
+public void TestMethod(int i, string s)
 {
-	TestMethod(i, j, 0);
+    var line = string.Format(s, i, 0);
 }
 
 public void TestMethod(int i, string s, int j = 0)
 {
-	var line = string.Format(s, i, j);
+    var line = string.Format(s, i, j);
 }
 ```
 
@@ -363,12 +452,12 @@ Code without diagnostic:
 ```csharp
 public void TestMethod(int i, string s)
 {
-	TestMethod(i, s, 0);
+    TestMethod(i, s, 0);
 }
 
 public virtual void TestMethod(int i, string s, int j = 0)
 {
-	var line = string.Format(s, i, j);
+    var line = string.Format(s, i, j);
 }
 ```
 
@@ -395,7 +484,16 @@ public class TestClassController : Controller
 
 ## ACL1010 - Nullable reference types enabled
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintainability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.28</td>
+</tr>
+</table>
 
 ACL1010 checks whether nullable reference types have been enabled on a project.
 
@@ -411,7 +509,16 @@ ACL1010 also provides a code fix, which inserts or updates the <Nullable> node i
 
 ## ACL1011 - Don't nest too many control statements
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintainability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-01.14</td>
+</tr>
+</table>
 
 ACL1011 checks how deeply nested control statements are to and raises a warning if a statement is too deeply nested, by default after 2.
 
@@ -455,7 +562,16 @@ Maximum allowed nesting can be configured in `.editorconfig` by setting `dotnet_
 
 ## ACL1012 - Don't pass predicates into 'Where' methods with too many clauses
 
-Category: Maintainability
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Maintainability</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>N/A</td>
+</tr>
+</table>
 
 ACL1012 checks how many logical and clauses are contained in a `Where` method call's predicate and raises a warning if there are too many, by default after 3.
 

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -329,9 +329,16 @@ ACL1005 adds an exclusion for controller actions, as they are often asynchronous
 
 ## ACL1006 - Code block does not have braces
 
-Category: Style
-
-Audacia coding standard: `CS-06.1`
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Style</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>CS-06.1</td>
+</tr>
+</table>
 
 ACL1006 is based on the Roslynator rule [RCS1007](https://josefpihrt.github.io/docs/roslynator/analyzers/RCS1007), which checks if statements such as `if`, `foreach` and `using` are followed by braces.
 

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -51,6 +51,8 @@ public class MyClass
 
 ## ACL1001 - Variable declarations should not use a magic number
 
+Category: Usage
+
 The ACL1001 rule checks for magic numbers being used in variable declarations. Magic numbers should generally be extracted to a well-named variable.
 
 Code with violation:
@@ -73,6 +75,8 @@ var next = previous + 1;
 ```
 
 ## ACL1002 - Methods should not exceed a predefined number of statements
+
+Category: Maintainability
 
 The ACL1002 rule checks the number of statements in a method (or property or constructor) against a maximum allowed value. This maximum value can be configured globally in the .editorconfig file, or locally using the `[MaxMethodLength]` attribute (this is in the `Audacia.CodeAnalysis.Analyzers.Helpers` NuGet package, which must be installed separately). In the absence of any configured value, a default maximum value of 10 is used.
 
@@ -121,13 +125,30 @@ public void MyMethod(string arg)
 		throw new ArgumentNullException(nameof(arg));
 	}
 
-	var one = 1;
-	var two = 2;
-	var three = 3;
+	const int one = 1;
+	const int two = 2;
+	const int three = 3;
+}
+```
+
+**Lines of logging are excluded from the statement count.** So in the following code, 3 lines would be counted rather than 5. This is because logging does not add complexity to the method, and we don't want to dissuade people from including them.
+
+```csharp
+public void MyMethod(string arg)
+{
+    _logger.LogInformation("Starting method");
+
+    const int one = 1;
+    const int two = 2;
+    const int three = 3;
+    
+    _logger.LogInformation("Finished method");
 }
 ```
 
 ## ACL1003 - Don't declare signatures with more than a predefined number of parameters
+
+Category: Maintainability
 
 The ACL1003 rule checks the number of parameters for a method or constructor against a maximum allowed value. This maximum value can be configured globally in the .editorconfig file, or locally using the `[MaxParameterCount]` attribute (this is in the `Audacia.CodeAnalysis.Analyzers.Helpers` NuGet package, which must be installed separately). In the absence of any configured value, a default maximum value of 4 is used.
 
@@ -158,7 +179,7 @@ dotnet_diagnostic.ACL1003.max_constructor_parameter_count = 5
 However, this does <b>not</b> work with the `record` reference type, and syntax synonyms (`record class`, `record struct`):
 ```csharp
 // No parameter count violation.
-public record Person(string a, int b, int c, int d, int e);
+public record Person(int a, int b, int c, int d, int e);
 
 // Attribute is ignored.
 [MaxParameterCount(1)]
@@ -169,7 +190,17 @@ public record struct School(int a, int b); // Record struct
 public record Exam(int a, int b); // Record class
 ```
 
+**`CancellationToken`s are excluded from the parameter count.** So in the following code, 4 parameters would be counted rather than 5.
+
+```csharp
+public async Task MyMethodAsync(int a, int b, int c, int d, CancellationToken cancellationToken)
+{
+}
+```
+
 ## ACL1004 - Don't use abbreviations
+
+Category: Naming
 
 The ACL1004 rule checks whether single characters or (specific) abbreviations have been used as a type, member, parameter or variable name.
 
@@ -183,6 +214,16 @@ Code with fix:
 
 ```csharp
 var index = 4;
+```
+
+The following is a full list of the abbreviations that are checked for:
+```cs
+"Btn", "Ctrl", "Frm", "Chk", "Cmb",
+"Ctx", "Dg", "Pnl", "Dlg", "Ex", "Lbl", 
+"Txt", "Mnu", "Prg", "Rb", "Cnt", "Tv", 
+"Ddl", "Fld", "Lnk", "Img", "Lit",
+"Vw", "Gv", "Dts", "Rpt", "Vld", "Pwd", 
+"Ctl", "Tm", "Mgr", "Flt", "Len", "Idx", "Str"
 ```
 
 There are two additional pieces of configuration that can be applied:
@@ -220,11 +261,15 @@ for (var i = 0; i < 10; i++)
 
 ## ACL1005 - Asynchronous method name is not suffixed with 'Async'
 
+Category: Naming
+
 ACL1005 is based on the Roslynator rule [RCS1046](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1046.md), which checks if asynchronous methods are suffixed with 'Async'.
 
 ACL1005 adds an exclusion for controller actions, as they are often asynchronous but should generally not be suffixed.
 
 ## ACL1006 - Code block does not have braces
+
+Category: Style
 
 ACL1006 is based on the Roslynator rule [RCS1007](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1007.md), which checks if statements such as `if`, `foreach` and `using` are followed by braces.
 
@@ -240,6 +285,8 @@ public void SomeMethod(string arg)
 The justification for this exclusion is that argument null checks, while advised, add noise to a codebase, and minimising this noise is useful.
 
 ## ACL1007 - ThenByDescending instead of OrderByDescending if follows OrderBy or OrderByDescending statement
+
+Category: Usage
 
 ACL1007 is similar in function to the Roslynator rule [RCS1200](https://github.com/JosefPihrt/Roslynator/blob/master/docs/analyzers/RCS1200.md), which checks if an `OrderBy` follows an `OrderBy` or `OrderByDescending`, and suggests using `ThenBy` instead if so.
 
@@ -258,6 +305,8 @@ var x = items.OrderBy(f => f.Surname).ThenByDescending(f => f.Name);
 ```
 
 ## ACL1008 - Controller actions have ProducesResponseType attribute
+
+Category: Maintainability
 
 ACL1008 checks if a controller action has at least one `ProducesResponseType` attribute and will produce a warning if not.
 This applies to controller actions defined by either an Http attribute (eg. `HttpGet`) or by the parent class inheriting the `ControllerBase` class.
@@ -284,6 +333,8 @@ public string Get()
 ```
 
 ## ACL1009 - Method overload should call another overload
+
+Category: Maintainability
 
 ACL1009 is based on CSharpGuidelinesAnalyzer [AV1551](https://github.com/dennisdoomen/CSharpGuidelines/blob/5.6.0/_rules/1551.md), which ensures the more overloaded method is called from other overloads.
 
@@ -344,6 +395,8 @@ public class TestClassController : Controller
 
 ## ACL1010 - Nullable reference types enabled
 
+Category: Maintainability
+
 ACL1010 checks whether nullable reference types have been enabled on a project.
 
 ACL1010 reports a warning if:
@@ -357,6 +410,8 @@ ACL1010 also provides a code fix, which inserts or updates the <Nullable> node i
 
 
 ## ACL1011 - Don't nest too many control statements
+
+Category: Maintainability
 
 ACL1011 checks how deeply nested control statements are to and raises a warning if a statement is too deeply nested, by default after 2.
 
@@ -399,6 +454,8 @@ This analyzer considers the following to be "control statements":
 Maximum allowed nesting can be configured in `.editorconfig` by setting `dotnet_diagnostic.ACL1011.max_control_statement_depth`.
 
 ## ACL1012 - Don't pass predicates into 'Where' methods with too many clauses
+
+Category: Maintainability
 
 ACL1012 checks how many logical and clauses are contained in a `Where` method call's predicate and raises a warning if there are too many, by default after 3.
 

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
@@ -15,7 +15,7 @@
         <PackageTags>Audacia.CodeAnalysis.Analyzers, analyzers</PackageTags>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageIcon>package-icon.png</PackageIcon>
-        <Version>1.7.0</Version>
+        <Version>1.7.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/DiagnosticId.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/DiagnosticId.cs
@@ -13,7 +13,7 @@
         public const string ControllerActionProducesResponseType = "ACL1008";
         public const string OverloadShouldCallOtherOverload = "ACL1009";
         public const string NullableReferenceTypesEnabled = "ACL1010";
-        public const string NestedControlStatementsAnalyzer = "ACL1011";
-        public const string MaximumWhereClausesAnalyzer = "ACL1012";
+        public const string NestedControlStatements = "ACL1011";
+        public const string MaximumWhereClauses = "ACL1012";
     }
 }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/HelpLinkUrlFactory.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/HelpLinkUrlFactory.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace Audacia.CodeAnalysis.Analyzers.Common
+{
+    /// <summary>
+    /// Class to construct help link URLs for our diagnostics.
+    /// </summary>
+    public static class HelpLinkUrlFactory
+    {
+        /// <summary>
+        /// All of our analyzers are documented at the same URL, with a different anchor per diagnostic.
+        /// </summary>
+        private const string ReadmeUrl = "https://github.com/audaciaconsulting/Audacia.CodeAnalysis/tree/master/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers";
+
+        public static string Create(string diagnosticId)
+        {
+            if (diagnosticId == null)
+            {
+                throw new ArgumentNullException(nameof(diagnosticId));
+            }
+
+            var helpLinkUrlPrefix = $"{ReadmeUrl}#{diagnosticId.ToLower()}---";
+            switch (diagnosticId)
+            {
+                case DiagnosticId.FieldWithUnderscore:
+                    return $"{helpLinkUrlPrefix}variable-declarations-should-not-use-a-magic-number";
+                case DiagnosticId.MagicNumber:
+                    return $"{helpLinkUrlPrefix}methods-should-not-exceed-a-predefined-number-of-statements";
+                case DiagnosticId.MethodLength:
+                    return $"{helpLinkUrlPrefix}dont-declare-signatures-with-more-than-a-predefined-number-of-parameters";
+                case DiagnosticId.ParameterCount:
+                    return $"{helpLinkUrlPrefix}dont-declare-signatures-with-more-than-a-predefined-number-of-parameters";
+                case DiagnosticId.NoAbbreviations:
+                    return $"{helpLinkUrlPrefix}dont-use-abbreviations";
+                case DiagnosticId.AsyncSuffix:
+                    return $"{helpLinkUrlPrefix}asynchronous-method-name-is-not-suffixed-with-async";
+                case DiagnosticId.IncludeBraces:
+                    return $"{helpLinkUrlPrefix}code-block-does-not-have-braces";
+                case DiagnosticId.ThenByDescendingAfterOrderBy:
+                    return $"{helpLinkUrlPrefix}thenbydescending-instead-of-orderbydescending-if-follows-orderby-or-orderbydescending-statement";
+                case DiagnosticId.ControllerActionProducesResponseType:
+                    return $"{helpLinkUrlPrefix}controller-actions-have-producesresponsetype-attribute";
+                case DiagnosticId.OverloadShouldCallOtherOverload:
+                    return $"{helpLinkUrlPrefix}method-overload-should-call-another-overload";
+                case DiagnosticId.NullableReferenceTypesEnabled:
+                    return $"{helpLinkUrlPrefix}nullable-reference-types-enabled";
+                case DiagnosticId.NestedControlStatements:
+                    return $"{helpLinkUrlPrefix}dont-nest-too-many-control-statements";
+                case DiagnosticId.MaximumWhereClauses:
+                    return $"{helpLinkUrlPrefix}dont-pass-predicates-into-where-methods-with-too-many-clauses";
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(diagnosticId),
+                        $"No help link has been set up for diagnostic id {diagnosticId}");
+                
+            }
+        }
+    }
+}

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/AsyncSuffix/AsyncSuffixAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/AsyncSuffix/AsyncSuffixAnalyzer.cs
@@ -19,13 +19,15 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.AsyncSuffix
         private const string Title = "Asynchronous method name is not suffixed with 'Async'.";
 
         private const string Description = "Asynchronous method names should be suffixed with 'Async'.";
-
+        
         private const string Category = DiagnosticCategory.Naming;
 
         private const bool IsEnabled = true;
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor Rule
-            = new DiagnosticDescriptor(Id, Title, MessageFormat, Category, Severity, IsEnabled, Description);
+            = new DiagnosticDescriptor(Id, Title, MessageFormat, Category, Severity, IsEnabled, Description, HelpLinkUrl);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
             => ImmutableArray.Create(Rule);

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/MaximumWhereClauses/MaximumWhereClausesAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/MaximumWhereClauses/MaximumWhereClausesAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Linq;
 using Audacia.CodeAnalysis.Analyzers.Common;
 using Audacia.CodeAnalysis.Analyzers.Settings;
@@ -14,7 +12,7 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.MaximumWhereClauses
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class MaximumWhereClausesAnalyzer : DiagnosticAnalyzer
     {
-        public const string Id = DiagnosticId.MaximumWhereClausesAnalyzer;
+        public const string Id = DiagnosticId.MaximumWhereClauses;
 
         public const int DefaultMaximumClauses = 3;
 
@@ -25,6 +23,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.MaximumWhereClauses
         private const string Description = "Don't pass predicates into 'Where' methods with too many clauses.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             Id,
@@ -32,8 +32,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.MaximumWhereClauses
             MessageFormat,
             DiagnosticCategory.Maintainability,
             DiagnosticSeverity.Warning,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/MethodLength/MethodLengthAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/MethodLength/MethodLengthAnalyzer.cs
@@ -26,6 +26,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.MethodLength
 
         private const string Description =
             "Methods should not exceed a predefined number of statements. You can configure the maximum number of allowed statements globally in the .editorconfig file, or locally using the [MaxMethodLength] attribute.";
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             Id,
@@ -33,8 +35,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.MethodLength
             MessageFormat,
             DiagnosticCategory.Maintainability,
             DiagnosticSeverity.Warning,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
 
         private static readonly Action<CompilationStartAnalysisContext> RegisterCompilationStartAction =
             RegisterCompilationStart;

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NestedControlStatements/NestedControlStatementsAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NestedControlStatements/NestedControlStatementsAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NestedControlStatements
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class NestedControlStatementsAnalyzer : DiagnosticAnalyzer
     {
-        public const string Id = DiagnosticId.NestedControlStatementsAnalyzer;
+        public const string Id = DiagnosticId.NestedControlStatements;
 
         public const int DefaultMaximumDepth = 2;
 
@@ -27,6 +27,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NestedControlStatements
         private const string Description = "Don't nest too many control statements.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             Id,
@@ -34,8 +36,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NestedControlStatements
             MessageFormat,
             DiagnosticCategory.Maintainability,
             DiagnosticSeverity.Warning,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
 
         private static readonly SyntaxKind[] ControlStatementKinds =
         {

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NoAbbreviations/NoAbbreviationsAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NoAbbreviations/NoAbbreviationsAnalyzer.cs
@@ -24,6 +24,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NoAbbreviations
         private const string Description = "Don't use abbreviations.";
 
         private const string Category = DiagnosticCategory.Naming;
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             Id,
@@ -31,8 +33,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NoAbbreviations
             MessageFormat,
             Category,
             DiagnosticSeverity.Warning,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
 
         private static readonly ImmutableArray<SymbolKind> MemberSymbolKinds =
             ImmutableArray.Create(SymbolKind.Property, SymbolKind.Method, SymbolKind.Field, SymbolKind.Event);

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NullableReferenceTypes/NullableReferenceTypesAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/NullableReferenceTypes/NullableReferenceTypesAnalyzer.cs
@@ -11,18 +11,23 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.NullableReferenceTypes
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class NullableReferenceTypesAnalyzer : DiagnosticAnalyzer
     {
+        private const string Id = DiagnosticId.NullableReferenceTypesEnabled;
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
+        
         /// <summary>
         /// The diagnostic rule for the nullable reference type analyzer. 
         /// </summary>
         private static readonly DiagnosticDescriptor Rule
             = new DiagnosticDescriptor(
-                DiagnosticId.NullableReferenceTypesEnabled,
+                Id,
                 DiagnosticMessages.NullableReferenceTypes.Title,
                 DiagnosticMessages.NullableReferenceTypes.MessageFormat,
                 DiagnosticCategory.Maintainability,
                 DiagnosticSeverity.Warning,
-                true,
-                DiagnosticMessages.NullableReferenceTypes.Description);
+                isEnabledByDefault: true,
+                DiagnosticMessages.NullableReferenceTypes.Description,
+                HelpLinkUrl);
 
         /// <summary>
         /// The collection of diagnostics for this analyzer.

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/OverloadShouldCallOtherOverload/OverloadShouldCallOtherOverloadAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/OverloadShouldCallOtherOverload/OverloadShouldCallOtherOverloadAnalyzer.cs
@@ -48,14 +48,18 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.OverloadShouldCallOtherOverload
         private const string Description = "Call the more overloaded method from other overloads.";
         private const string Category = DiagnosticCategory.Maintainability;
         private const DiagnosticSeverity Serverity = DiagnosticSeverity.Warning;
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
+        
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             Id,
             Title,
             MessageFormat,
             Category,
             Serverity,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
         private static readonly Action<CompilationStartAnalysisContext> RegisterCompilationStartAction = RegisterCompilationStart;
 
         private static readonly DiagnosticDescriptor MakeVirtualRule = new DiagnosticDescriptor(Id, Title,

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/ParameterCount/ParameterCountAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/ParameterCount/ParameterCountAnalyzer.cs
@@ -21,6 +21,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.ParameterCount
             "{0} contains {1} parameters, which exceeds the maximum of {2} parameters.";
 
         private const string Description = "Don't declare signatures with more than a predefined number of parameters.";
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
         private static readonly DiagnosticDescriptor ParameterCountRule = new DiagnosticDescriptor(
             Id,
@@ -28,8 +30,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.ParameterCount
             ParameterCountMessageFormat,
             DiagnosticCategory.Maintainability,
             DiagnosticSeverity.Warning,
-            true,
-            Description);
+            isEnabledByDefault: true,
+            Description,
+            HelpLinkUrl);
 
         private static readonly Action<CompilationStartAnalysisContext> RegisterCompilationStartAction =
             RegisterCompilationStart;

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/ThenByDescendingAfterOrderBy/ThenByDescendingAfterOrderByAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/ThenByDescendingAfterOrderBy/ThenByDescendingAfterOrderByAnalyzer.cs
@@ -18,8 +18,10 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.ThenByDescendingAfterOrderBy
         private const string Title = "OrderByDescending statement follows OrderBy or OrderByDescending statement.";
         private const string MessageFormat = "ThenByDescending statement should replace OrderByDescending when following OrderBy or OrderByDescending statement.";
         private const string Description = "Use ThenOrderByDescending rather than OrderByDescending.";
+        
+        private static readonly string HelpLinkUrl = HelpLinkUrlFactory.Create(Id);
 
-        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(Id, Title, MessageFormat, DiagnosticCategory.Usage, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(Id, Title, MessageFormat, DiagnosticCategory.Usage, DiagnosticSeverity.Warning, isEnabledByDefault: true, Description, HelpLinkUrl);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
Currently, selecting a link to the code analysis rule brings you up an error page:
![image](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/assets/47522421/b939d3e3-5de3-475c-9d69-6e25004339fa)

This PR is to provide a URL to the `HelpLinkUri` so that developers can get more information on the warnings.

| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ❌ |
| README updated | ✔ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |