### PR TITLE
#169057: Allow MaxParameterCount attribute on primary class constructors

### DIFF
--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers.Helpers/src/Audacia.CodeAnalysis.Analyzers.Helpers/ParameterCount/MaxParameterCountAttribute.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers.Helpers/src/Audacia.CodeAnalysis.Analyzers.Helpers/ParameterCount/MaxParameterCountAttribute.cs
@@ -5,7 +5,7 @@ namespace Audacia.CodeAnalysis.Analyzers.Helpers.ParameterCount
     /// <summary>
     /// Overrides the maximum allowed number of parameters to a method or constructor to a given value.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class)]
     public sealed class MaxParameterCountAttribute : Attribute
     {
         /// <summary>

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/ParameterCountAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/ParameterCountAnalyzerTests.cs
@@ -279,6 +279,29 @@ namespace TestNamespace
         }
 
         [TestMethod]
+        public void No_Diagnostics_For_Class_Primary_Constructor_Parameters_Equal_To_Max_Allowed_Number_Overridden_Via_Attribute()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    [MaxParameterCount(5)]
+    public class TestClass(int a, int b, int c, int d, int e) { }
+
+    public sealed class MaxParameterCountAttribute : System.Attribute
+    {
+        public int ParameterCount { get; }
+
+        public MaxParameterCountAttribute(int parameterCount)
+        {
+            ParameterCount = parameterCount;
+        }
+    }
+}";
+
+            VerifyNoDiagnostic(test);
+        }
+
+        [TestMethod]
         public void Diagnostics_For_Method_Parameters_Greater_Than_Max_Allowed_Overridden_Via_Attribute()
         {
             var test = @"

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/ParameterCountAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/ParameterCountAnalyzerTests.cs
@@ -126,7 +126,7 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void No_Diagnostics_For_Constructor_Parameters_Less_Than_Max_Allowed_Number()
+        public void No_Diagnostics_For_Class_Constructor_Parameters_Less_Than_Max_Allowed_Number()
         {
             var test = @"
 namespace TestNamespace
@@ -160,7 +160,7 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void No_Diagnostics_For_Constructor_Parameters_Equal_To_Max_Allowed_Number()
+        public void No_Diagnostics_For_Class_Constructor_Parameters_Equal_To_Max_Allowed_Number()
         {
             var test = @"
 namespace TestNamespace
@@ -200,7 +200,7 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void Diagnostic_For_Constructor_Parameters_More_Than_Max_Allowed_Number()
+        public void Diagnostic_For_Class_Constructor_Parameters_More_Than_Max_Allowed_Number()
         {
             var test = @"
 namespace TestNamespace
@@ -217,6 +217,24 @@ namespace TestNamespace
                 memberName: "Constructor for 'TestClass'",
                 lineNumber: 6,
                 column: 16,
+                parameterCount: 5);
+
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_For_Class_Primary_Constructor_Parameters_More_Than_Max_Allowed_Number()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    public class TestClass(int a, int b, int c, int d, int e);
+}";
+
+            var expected = BuildExpectedResult(
+                memberName: "Constructor for 'TestClass'",
+                lineNumber: 4,
+                column: 18,
                 parameterCount: 5);
 
             VerifyDiagnostic(test, expected);
@@ -251,7 +269,7 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void No_Diagnostics_For_Constructor_Parameters_Equal_To_Max_Allowed_Number_Overridden_Via_Attribute()
+        public void No_Diagnostics_For_Class_Constructor_Parameters_Equal_To_Max_Allowed_Number_Overridden_Via_Attribute()
         {
             var test = @"
 namespace TestNamespace
@@ -285,7 +303,7 @@ namespace TestNamespace
 namespace TestNamespace
 {
     [MaxParameterCount(5)]
-    public class TestClass(int a, int b, int c, int d, int e) { }
+    public class TestClass(int a, int b, int c, int d, int e);
 
     public sealed class MaxParameterCountAttribute : System.Attribute
     {
@@ -296,6 +314,30 @@ namespace TestNamespace
             ParameterCount = parameterCount;
         }
     }
+}";
+
+            VerifyNoDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void No_Diagnostics_For_Class_Primary_Constructor_Parameters_Equal_To_Max_Allowed_Number()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    public class TestClass(int a, int b, int c, int d);
+}";
+
+            VerifyNoDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void No_Diagnostics_For_Class_Primary_Constructor_Parameters_Less_Than_Max_Allowed_Number()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    public class TestClass(int i, int j);
 }";
 
             VerifyNoDiagnostic(test);
@@ -337,7 +379,7 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void Diagnostics_For_Constructor_Parameters_Greater_Than_Max_Allowed_Overridden_Via_Attribute()
+        public void Diagnostics_For_Class_Constructor_Parameters_Greater_Than_Max_Allowed_Overridden_Via_Attribute()
         {
             var test = @"
 namespace TestNamespace
@@ -372,41 +414,13 @@ namespace TestNamespace
         }
 
         [TestMethod]
-        public void Diagnostics_For_Record_Constructor_Parameters_Equal_To_Max_Allowed_Number()
-        {
-            var test = @"
-namespace TestNamespace
-{
-    public record TestClass (int a, int b, int c, int d)
-    {
-    }
-}";
-            VerifyNoDiagnostic(test);
-        }
-
-        [TestMethod]
-        public void Diagnostics_For_Record_Constructor_Parameters_Greater_Than_Max_Allowed()
-        {
-            var test = @"
-namespace TestNamespace
-{
-    public record TestClass (int a, int b, int c, int d, int e, int f)
-    {
-    }
-}";
-            VerifyDiagnostic(test);
-        }
-
-        [TestMethod]
-        public void Diagnostics_For_Record_Constructor_Parameters_Greater_Than_Max_Allowed_Overridden_Via_Attribute()
+        public void Diagnostics_For_Class_Primary_Constructor_Parameters_Greater_Than_Max_Allowed_Overridden_Via_Attribute()
         {
             var test = @"
 namespace TestNamespace
 {
     [MaxParameterCountAttribute(1)]
-    public record TestClass (int a, int b, int c, int d, int e, int f)
-    {
-    }
+    public class TestClass(int a, int b);
 
     public sealed class MaxParameterCountAttribute : System.Attribute
     {
@@ -418,7 +432,62 @@ namespace TestNamespace
         }
     }
 }";
-            VerifyDiagnostic(test);
+
+            var expected = BuildExpectedResult(
+                memberName: "Constructor for 'TestClass'",
+                lineNumber: 5,
+                column: 18,
+                parameterCount: 2,
+                maxParameterCount: 1);
+
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void No_Diagnostics_For_Record_Primary_Constructor_Parameters_Equal_To_Max_Allowed_Number_Overridden_Via_Attribute()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    [MaxParameterCount(5)]
+    public record TestRecord(int a, int b, int c, int d, int e);
+
+    public sealed class MaxParameterCountAttribute : System.Attribute
+    {
+        public int ParameterCount { get; }
+
+        public MaxParameterCountAttribute(int parameterCount)
+        {
+            ParameterCount = parameterCount;
+        }
+    }
+}";
+
+            VerifyNoDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void No_Diagnostics_For_Record_Primary_Constructor_Parameters_Equal_To_Max_Allowed_Number()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    public record TestRecord(int a, int b, int c, int d);
+}";
+
+            VerifyNoDiagnostic(test);
+        }
+
+        [TestMethod]
+        public void No_Diagnostics_For_Record_Primary_Constructor_Parameters_Less_Than_Max_Allowed_Number()
+        {
+            var test = @"
+namespace TestNamespace
+{
+    public record TestRecord(int i, int j);
+}";
+
+            VerifyNoDiagnostic(test);
         }
     }
 }

--- a/eslint/plugins/audacia-eslint-plugin-angular/package-lock.json
+++ b/eslint/plugins/audacia-eslint-plugin-angular/package-lock.json
@@ -438,11 +438,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -906,9 +907,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1194,6 +1196,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1926,6 +1929,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },


### PR DESCRIPTION
| Action | Done? |
| --- | --- |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |