### PR TITLE
Bug/179301 incorrect csharpguidelinesanalyzer reference

### DIFF
--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
@@ -14,10 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audacia.CodeAnalysis.Analyzers" Version="1.10.0" />
-    <PackageReference Include="CSharpGuidelinesAnalyzer" Version="3.8.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="CSharpGuidelinesAnalyzer" Version="3.8.5" />
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.7" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.3" />

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -1,6 +1,16 @@
 ﻿# Changelog
 
-### 1.10.0.0 - 2024-08-21
+## 1.10.1 - 2024-09-23
+### Added
+- No new functionality added
+
+### Changed
+- No functionality changed
+
+### Fixed
+- Correct package reference for "CSharpGuidelinesAnalyzer" ([e843945](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/commit/e843945f9a791fac19ab1e7fe0f53415a6839ae6))
+
+## 1.10.0.0 - 2024-08-21
 ### Added
 - Added new rule "DoNotUseProducesResponseTypeWithTypedResults" (ACL1015) ([dc9869a](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/31/commits/dc9869a388a3343ff6bedb613b224ec9a6205e86))
 - Added new rule "UseTypedResultsInsteadOfIActionResult " (ACL1016) ([dc9869a](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/31/commits/dc9869a388a3343ff6bedb613b224ec9a6205e86))


### PR DESCRIPTION
| Action | Done? |
| --- | --- |
| CHANGELOG updated | ✔ |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ✔ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |
