### PR TITLE
#178353: Allow Vue data-test attribute to check bound attributes

### DIFF
--- a/eslint/plugins/audacia-eslint-plugin-vue/CHANGELOG.md
+++ b/eslint/plugins/audacia-eslint-plugin-vue/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.1 - 2024-10-02
+### Added
+- No new functionality added
+
+### Changed
+- Allow `data-test` attribute rule to detect bound attributes, e.g. `:data-test` ([60115e9](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/commit/60115e9d2de22a54bbf2057b15e93401dd2dfe26))
+
 ## 1.1.0 - 2023-07-04
 ### Added
 - No new functionality added

--- a/eslint/plugins/audacia-eslint-plugin-vue/lib/rules/data-test-attribute.js
+++ b/eslint/plugins/audacia-eslint-plugin-vue/lib/rules/data-test-attribute.js
@@ -159,11 +159,17 @@ module.exports = {
     }
 
     function isAttributeValid(attribute) {
-      if (!attribute || !attribute.value || !attribute.value.value) {
+      if (!attribute || !attribute.value) {
         return false;
       }
 
-      return true;
+      // Check a bound attribute e.g. :data-test="123" has any form of expression
+      if (attribute.directive) {
+        return !!attribute.value.expression;
+      }
+
+      // If it is a static attribute, ensure some value is set
+      return !!attribute.value.value;
     }
 
     function generateFixer(node, attribute) {
@@ -177,6 +183,9 @@ module.exports = {
         const endOfStartTag = node.startTag.range[1] - (node.startTag.selfClosing ? 3 : 1);
         range = [endOfStartTag, endOfStartTag];
         fixValue = ` ${configuration.testAttribute}="${id}"`;
+      } else if (attribute.directive) {
+        // If the attribute is bound (e.g. :data-test) then do no fix
+        return undefined;
       } else if (attribute.value === null) {
         // The attribute exists but has no value so add the id
         range = [attribute.range[1], attribute.range[1]];

--- a/eslint/plugins/audacia-eslint-plugin-vue/tests/lib/rules/data-test-attribute.js
+++ b/eslint/plugins/audacia-eslint-plugin-vue/tests/lib/rules/data-test-attribute.js
@@ -131,6 +131,11 @@ tester.run('data-test-attribute', rule, {
       code: '<template><input dataOtherAttribute="test-id"></template>',
       options: [{ testAttribute: 'dataOtherAttribute' }],
     },
+    // bound test attributes
+    {
+      name: 'input element with bound test attribute',
+      code: '<template><input :data-test="myVar"></template>',
+    },
   ],
   invalid: [
     // @click events
@@ -359,6 +364,21 @@ tester.run('data-test-attribute', rule, {
       errors: ["Elements with click events should include a 'dataOtherAttribute' attribute"],
       output: '<template><div @click="foobar()" dataOtherAttribute="test-id"></div></template>',
       options: [{ enableFixer: true, testAttribute: 'dataOtherAttribute' }],
-    }
+    },
+    // input elements with empty bound test attribute
+    {
+      name: 'input element with no value in bound test attribute are not fixed',
+      code: '<template><input :data-test></template>',
+      errors: ["input elements should include a 'data-test' attribute"],
+      output: '<template><input :data-test></template>',
+      options: [{ enableFixer: true }],
+    },
+    {
+      name: 'input element with empty value in bound test attribute are not fixed',
+      code: '<template><input :data-test=""></template>',
+      errors: ["input elements should include a 'data-test' attribute"],
+      output: '<template><input :data-test=""></template>',
+      options: [{ enableFixer: true }],
+    },
   ],
 });


### PR DESCRIPTION
Fixes #178353

| Action | Done? |
| --- | --- |
| CHANGELOG updated | ✔ |
| Code compiles and unit tests all pass locally | ✔ |
| Debug/console log code removed | ✔ |
| Commented out code removed | ✔ |
| Unit tests added/updated | ✔ |
| README updated | ❌ |
| Considered: <br /> - Performance <br /> - Security <br /> - Logging | ✔ |
| Licenses of any new/upgraded dependencies checked, with no copyleft dependencies introduced | ✔ |
