### PR TITLE
feature/174912-document-how-c-sharp-versions-are-supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,17 @@ The `Audacia.CodeAnalysis` repository change history can be found in the followi
 
 # Contributing
 We welcome contributions! Please feel free to check our [Contribution Guidlines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
+
+## Updating the analyzers to support a new C# version
+
+If any of the dependent analyzer packages are being upgraded to reference a newer version of `Microsoft.CodeAnalysis.CSharp.Workspaces` that results in a new minimum supported C# version (as per the official [Roslyn NuGet-packages.md](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md)), the major version of `Audacia.CodeAnalysis` must be incremented.
+
+The description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
+
+e.g
+
+```csharp
+    <PropertyGroup>
+        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
+    </PropertyGroup>
+```

--- a/README.md
+++ b/README.md
@@ -22,17 +22,3 @@ The `Audacia.CodeAnalysis` repository change history can be found in the followi
 
 # Contributing
 We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
-
-## Updating the analyzers to support a new C# version
-
-If any of the dependent analyzer packages are being upgraded to reference a newer version of `Microsoft.CodeAnalysis.CSharp.Workspaces` that results in a new minimum supported C# version (as per the official [Roslyn NuGet-packages.md](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md)), the major version of `Audacia.CodeAnalysis` must be incremented.
-
-The description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
-
-e.g
-
-```csharp
-    <PropertyGroup>
-        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
-    </PropertyGroup>
-```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The `Audacia.CodeAnalysis` repository change history can be found in the followi
   - ES Lint Plugin Vue [changelog](eslint/plugins/audacia-eslint-plugin-vue/CHANGELOG.md)
 
 # Contributing
-We welcome contributions! Please feel free to check our [Contribution Guidlines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
+We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
 
 ## Updating the analyzers to support a new C# version
 

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Description>This package supports workspaces operating a minimum version of C# 12 and .NET 8.</Description>
+        <Description>This package supports projects operating a minimum version of C# 12 and .NET 8.</Description>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/Audacia.CodeAnalysis.AspNetCore.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/Audacia.CodeAnalysis.AspNetCore.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
-        <Description>Code analysis packages and rulesets for ASP.NET Core apps.</Description>
+        <Description>
+            Code analysis packages and rulesets for ASP.NET Core apps.
+            This package supports projects operating a minimum version of C# 12 and .NET 8.
+        </Description>
         <Authors>Audacia</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
@@ -16,7 +16,10 @@ The Description in the `.csproj` must be updated to include the minimum version 
 
 e.g
 ```xml
-    <PropertyGroup>
-        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
-    </PropertyGroup>
+<PropertyGroup>
+    <Description>
+        Code analysis packages and rulesets for apps using Entity Framework Core.
+        This package supports projects operating a minimum version of C# 12 and .NET 8.
+    </Description>
+</PropertyGroup>
 ```

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
@@ -15,7 +15,7 @@ If any of the dependent analyzer packages are being upgraded to reference a newe
 The Description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
 
 e.g
-```csharp
+```xml
     <PropertyGroup>
         <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
     </PropertyGroup>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/README.md
@@ -3,3 +3,20 @@
 The [CodeAnalysis.AspNetCore.ruleset](https://github.com/DotNetAnalyzers/AspNetCoreAnalyzers) provides extra configuration for ASP.NET Core analyzers, and disables certain other rules where controller actions do not align with the rule, for example adding an `Async` suffix to all `async` methods. This ruleset is applicable to ASP.NET Core Web API projects.
 
 See the [Audacia.CodeAnalysis](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/blob/master/README.md) project for full information about how to use the code analysis library.
+
+# Contributing
+
+We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
+
+## Updating the analyzers to support a new C# version
+
+If any of the dependent analyzer packages are being upgraded to reference a newer version of `Microsoft.CodeAnalysis.CSharp.Workspaces` that results in a new minimum supported C# version (as per the official [Roslyn NuGet-packages.md](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md)), the major version of `Audacia.CodeAnalysis.EntityFrameworkCore` must be incremented.
+
+The Description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
+
+e.g
+```csharp
+    <PropertyGroup>
+        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
+    </PropertyGroup>
+```

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Description>
             Code analysis packages and rulesets for apps using Entity Framework Core.
-            This package supports workspaces operating a minimum version of C# 12 and .NET 8.
+            This package supports projects operating a minimum version of C# 12 and .NET 8.
         </Description>
         <Authors>Audacia</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <Description>Code analysis packages and rulesets for apps using Entity Framework Core.</Description>
+        <Description>
+            Code analysis packages and rulesets for apps using Entity Framework Core.
+            This package supports workspaces operating a minimum version of C# 12 and .NET 8.
+        </Description>
         <Authors>Audacia</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/Audacia.CodeAnalysis.EntityFrameworkCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <Description>Code analysis packages and rulesets for apps using Entity Framework Core.</Description>
         <Authors>Audacia</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.EntityFrameworkCore/README.md
@@ -3,3 +3,20 @@
 The [CodeAnalysis.EntityFrameworkCore.ruleset](https://github.com/dotnet/efcore/tree/main/src/EFCore.Analyzers) adds analyzers for Entity Framework Core for projects using this library.
 
 See the [Audacia.CodeAnalysis](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/blob/master/README.md) project for full information about how to use the code analysis library.
+
+# Contributing
+We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
+
+## Updating the analyzers to support a new C# version
+
+If any of the dependent analyzer packages are being upgraded to reference a newer version of Microsoft.CodeAnalysis.CSharp.Workspaces that results in a new minimum supported C# version (as per the official [Roslyn NuGet-packages.md](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md)), the major version of Audacia.CodeAnalysis.EntityFrameworkCore must be incremented.
+
+The description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
+
+e.g
+
+```xml
+    <PropertyGroup>
+        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
+    </PropertyGroup>
+```

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>This package supports workspaces operating a minimum version of C# 12 and .NET 8.</Description>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <Authors>Audacia</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>This package supports workspaces operating a minimum version of C# 12 and .NET 8.</Description>
+    <Description>This package supports projects operating a minimum version of C# 12 and .NET 8.</Description>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <Authors>Audacia</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
@@ -140,3 +140,20 @@ All rules are prefixed with `DOC`.
 [Microsoft.EntityFrameworkCore.Analyzers](https://github.com/dotnet/efcore/tree/main/src/EFCore.Analyzers) provides C# analyzers for Entity Framework Core.
 
 All rules are prefixed `EF`.
+
+# Contributing
+We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.
+
+## Updating the analyzers to support a new C# version
+
+If any of the dependent analyzer packages are being upgraded to reference a newer version of `Microsoft.CodeAnalysis.CSharp.Workspaces` that results in a new minimum supported C# version (as per the official [Roslyn NuGet-packages.md](https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md)), the major version of `Audacia.CodeAnalysis` must be incremented.
+
+The description in the `.csproj` must be updated to include the minimum version of C#/.NET that is supported.
+
+e.g
+
+```csharp
+    <PropertyGroup>
+        <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
+    </PropertyGroup>
+```

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
@@ -152,7 +152,7 @@ The description in the `.csproj` must be updated to include the minimum version 
 
 e.g
 
-```csharp
+```xml
     <PropertyGroup>
         <Description>This package supports C# 12 and .NET 8 as a minimum.</Description>
     </PropertyGroup>


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ❎ No version change required
- The version update comes in a later PBI (187914)

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ❎ No new/upgraded dependencies