### PR TITLE
feature/184914-release-audacia.codeanalysis-verions-1.12.0

### DIFF
--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added configuration for several new rules in the `Audacia.CodeAnalysis` base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files))
 
 ### Changed
+- All CodeAnalysis README files have been updated with a description to remind developers that if any of the dependent analyzer packages are being upgraded to reference a newer version of `Microsoft.CodeAnalysis.CSharp.Workspaces` that results in a new minimum supported C# version (as per https://github.com/dotnet/roslyn/blob/main/docs/wiki/NuGet-packages.md), the major version of Audacia.CodeAnalysis must be incremented.
+- All CodeAnalysis `.csproj` files have been updated to include the minimum version of C#/.NET that is supported.
 - Reduced the severity of several overzealous analyzers the base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)).
 - The following packages have been updated ([3a34df9e](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/71/files)):
   - `Audacia.CodeAnalysis.Analyzers` from version 1.11.0 to version 1.12.0.

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -2,17 +2,18 @@
 
 ## 1.12.0 - 2025-01-02
 ### Added
-- Added the following new rules to the `Audacia.CodeAnalysis` base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)):
-  - ALC1018: Code analysis suppression requires justification.
-  - CA2254: [USAGE] Template should be a static expression.
-  - CA2255: [USAGE] The ModuleInitializer attribute should not be used in libraries.
+- Added configuration for several new rules in the `Audacia.CodeAnalysis` base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files))
 
 ### Changed
-- Reduced the severity of the following overzealous Analyzers the base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)):
-  - SA1404: A Code Analysis SuppressMessage attribute does not include a justification.
-    - This has been suppressed as it is now covered by custom analyzer ACL1018.
-  - IDE0046: Use conditional expression for return.
-  - IDE0058: Remove unused expression value.
+- Reduced the severity of several overzealous analyzers the base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)).
+- The following packages have been updated ([3a34df9e](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/71/files)):
+  - `Audacia.CodeAnalysis.Analyzers` from version 1.11.0 to version 1.12.0.
+  - `IDisposableAnalyzers` from version 4.0.7 to version 4.0.8.
+  - `Roslynator.Analyzers` from version 4.12.3 to version 4.12.10.
+  - As part of the package updates the base editorconfig has been updated so that:
+    - any deprecated Roslynator rules between RCS1001 to RCS1268 have been removed.
+    - any new Roslynator rules between RCS1001 to RCS1268 have been added with an appropriate severity.
+    - the analyzer SA1404 has been suppressed as it has now been superseded by custom analyzer ACL1018.
 
 ## 1.11.0 - 2024-09-25
 ### Added

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -1,5 +1,19 @@
 ﻿# Changelog
 
+## 1.12.0 - 2025-01-02
+### Added
+- Added the following new rules to the `Audacia.CodeAnalysis` base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)):
+  - ALC1018: Code analysis suppression requires justification.
+  - CA2254: [USAGE] Template should be a static expression.
+  - CA2255: [USAGE] The ModuleInitializer attribute should not be used in libraries.
+
+### Changed
+- Reduced the severity of the following overzealous Analyzers the base .editorconfig ([05a1b94](https://github.com/audaciaconsulting/Audacia.CodeAnalysis/pull/68/files)):
+  - SA1404: A Code Analysis SuppressMessage attribute does not include a justification.
+    - This has been suppressed as it is now covered by custom analyzer ACL1018.
+  - IDE0046: Use conditional expression for return.
+  - IDE0058: Remove unused expression value.
+
 ## 1.11.0 - 2024-09-25
 ### Added
 - No new functionality added

--- a/dotnet-roslyn/config/Directory.Build.props
+++ b/dotnet-roslyn/config/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>1.11.0</Version>
+        <Version>1.12.0</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ✔ Licenses of new/upgraded dependencies checked, with no copyleft dependencies introduced


# Draft MS Teams Communication of Release Changes:

## Release Update: Audacia.CodeAnalysis 1.12.0

Heads up that version 1.12.0 of the Audacia.CodeAnalysis NuGet package has just been published.

### ✨ **What's Added**  
- New configuration for several rules in the base `.editorconfig` file to improve code analysis consistency.  

### 🔄 **What's Changed**  
- 📄 **Documentation Update**: README files now include reminders about upgrading dependent analyzer packages that impact the minimum supported C# version.  
-  **Project Configuration**: `.csproj` files updated to reflect the minimum supported C#/.NET versions.  
-  **Analyzer Adjustments**: Reduced the severity of overly aggressive analyzers in `.editorconfig`.  
-  **Package Upgrades**:  
  - `Audacia.CodeAnalysis.Analyzers`: v1.11.0 → v1.12.0  
  - `IDisposableAnalyzers`: v4.0.7 → v4.0.8  
  - `Roslynator.Analyzers`: v4.12.3 → v4.12.10  

###  **Key Highlights**  
- Deprecated Roslynator rules (RCS1001–RCS1268) removed; new rules added with appropriate severities.  
- Superseded analyzer SA1404 suppressed in favor of custom analyzer ACL1018.  

Please upgrade when you get an opportunity to do so. Let us know if you encounter any issues or have questions about the updates. Happy coding! 😊
