### PR TITLE
feat: Add new LogMessagesNamedPropertiesMustBeUsed rule #210698

### DIFF
--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/CHANGELOG.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Added new rule "LogMessagesNoExceptionsAsTemplateParameters" (ACL1025).
     - This rule checks that exceptions are not included as template parameters in log messages, ensuring that exception details are properly logged and not lost in the message formatting.
     - This rule works with `Microsoft.Extensions.Logging.ILogger` methods.
+- Added new rule "LogMessagesNamedPropertiesMustBeUsed" (ACL1026).
+    - This rule checks that positional properties are not included as template parameters in log messages, ensuring that all properties are named and improving readability of log messages.
+    - This rule works with `Microsoft.Extensions.Logging.ILogger` methods.
 
 ### Changed
 - No changes to existing functionality

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -1271,14 +1271,13 @@ Some examples of common conventions and their regex patterns are as follows:
 ACL1023 checks if named properties within log messages are in PascalCase and will produce a warning if not.
 It also supports Serilog's destructuring operator (@), and will ignore this when checking the case of the property name.
 
-Positional properties will trigger a diagnostic as named properties should always be used.
+Positional properties will not trigger a diagnostic as ACL1026 handles these separately.
 
 All log methods from `Microsoft.Extensions.Logging` are supported.
 
 Code with diagnostic:
 ```csharp
     _logger.LogInformation("User {userId} logged in with IP {ip_address}", userId, ipAddress);
-    _logger.LogInformation("User {0} logged in with IP {1}", userId, ipAddress);
     _logger.LogInformation("User {@user} performed an action", user);
     _logger.LogInformation("{{UserId}}: {userId}", userId);
     _logger.LogInformation($"{{{{UserId}}}}: {{userId}}", userId);
@@ -1288,6 +1287,7 @@ Code with diagnostic:
 Code without diagnostic:
 ```csharp
     _logger.LogInformation("User {UserId} logged in with IP {IpAddress}", userId, ipAddress);
+    _logger.LogInformation("User {0} logged in with IP {1}", userId, ipAddress);
     _logger.LogInformation("User {@User} performed an action", user);
     _logger.LogInformation("{{UserId}}: {UserId}", userId);
     _logger.LogInformation($"{{{{UserId}}}}: {{UserId}}", userId);
@@ -1364,4 +1364,37 @@ Code without diagnostic:
     _logger.LogInformation(anError, "An error occurred");
     _logger.LogInformation(anError, "An error occurred for user {UserId}", userId);
     _logger.LogInformation(exception: [new System.Exception()], message: "An error occurred");
+```
+
+## ACL1026 - Named properties should be used in logging messages
+
+<table>
+<tr>
+    <td>Category:</td>
+    <td>Logging</td>
+</tr>
+<tr>
+    <td>Audacia coding standard:</td>
+    <td>N/A</td>
+</tr>
+</table>
+
+ACL1026 checks whether positional properties are used within logging message templates and will produce a warning if so.
+
+All log methods from `Microsoft.Extensions.Logging` are supported.
+
+Code with diagnostic:
+```csharp
+    _logger.LogInformation("Message: {0}", message);
+    _logger.LogInformation("Message: {@0}", message);
+    _logger.LogInformation("Amount: {0:c}", amount);
+    _logger.LogInformation("Message: {0} Info: {1}", message, info);
+    _logger.LogInformation("Message: {Message} Info: {0}", message, info);
+```
+
+Code without diagnostic:
+```csharp
+    _logger.LogInformation("Message: {Message}", message);
+    _logger.LogInformation("Amount: {Amount:c}", amount);
+    _logger.LogInformation("Message: {Message} Info: {Info}", message, info);
 ```

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/README.md
@@ -1282,6 +1282,10 @@ Code with diagnostic:
     _logger.LogInformation("{{UserId}}: {userId}", userId);
     _logger.LogInformation($"{{{{UserId}}}}: {{userId}}", userId);
     _logger.LogInformation("UserId: {userId:N0}", userId);
+
+    // Variables storing the message template are also checked
+    var message = "User {userId} logged in";
+    _logger.LogInformation(message, userId);
 ```
 
 Code without diagnostic:
@@ -1292,6 +1296,10 @@ Code without diagnostic:
     _logger.LogInformation("{{UserId}}: {UserId}", userId);
     _logger.LogInformation($"{{{{UserId}}}}: {{UserId}}", userId);
     _logger.LogInformation("UserId: {UserId:N0}", userId);
+
+    // Variables storing the message template are also checked
+    var message = "User {UserId} logged in";
+    _logger.LogInformation(message, userId);
 ```
 
 ## ACL1024 - Named properties within log messages should not be duplicated
@@ -1318,6 +1326,10 @@ Code with diagnostic:
     _logger.LogInformation("{{UserId}}: {UserId} and {UserId}", userId, targetUserId);
     _logger.LogInformation($"{{{{UserId}}}}: {{UserId}} and {{UserId}}", userId, targetUserId);
     _logger.LogInformation("UserId: {UserId:N0} and {UserId:c}", userId, targetUserId);
+
+    // Variables storing the message template are also checked
+    var message = "User {UserId} logged in with IP {UserId}";
+    _logger.LogInformation(message, userId, ipAddress);
 ```
 
 Code without diagnostic:
@@ -1327,6 +1339,10 @@ Code without diagnostic:
     _logger.LogInformation("{{UserId}}: {UserId} and {TargetUserId}", userId, targetUserId);
     _logger.LogInformation($"{{{{UserId}}}}: {{UserId}} and {{TargetUserId}}", userId, targetUserId);
     _logger.LogInformation("UserId: {UserId:N0} and {TargetUserId:c}", userId, targetUserId);
+
+    // Variables storing the message template are also checked
+    var message = "User {UserId} logged in with IP {IpAddress}";
+    _logger.LogInformation(message, userId, ipAddress);
 ```
 
 ## ACL1025 - Exceptions should not be used in log message templates
@@ -1390,6 +1406,10 @@ Code with diagnostic:
     _logger.LogInformation("Amount: {0:c}", amount);
     _logger.LogInformation("Message: {0} Info: {1}", message, info);
     _logger.LogInformation("Message: {Message} Info: {0}", message, info);
+
+    // Variables storing the message template are also checked
+    var template = "Message: {0}";
+    _logger.LogInformation(template, message);
 ```
 
 Code without diagnostic:
@@ -1397,4 +1417,8 @@ Code without diagnostic:
     _logger.LogInformation("Message: {Message}", message);
     _logger.LogInformation("Amount: {Amount:c}", amount);
     _logger.LogInformation("Message: {Message} Info: {Info}", message, info);
+
+    // Variables storing the message template are also checked
+    var template = "Message: {Message}";
+    _logger.LogInformation(template, message);
 ```

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/DiagnosticId.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Common/DiagnosticId.cs
@@ -28,5 +28,6 @@
         public const string LogMessagesNamedPropertiesPascalCase = "ACL1023";
         public const string LogMessagesNoDuplicateParameters = "ACL1024";
         public const string LogMessagesNoExceptionsAsTemplateParameters = "ACL1025";
+        public const string LogMessagesNamedPropertiesMustBeUsed = "ACL1026";
     }
 }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Extensions/SyntaxExtensions.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Extensions/SyntaxExtensions.cs
@@ -546,13 +546,48 @@ namespace Audacia.CodeAnalysis.Analyzers.Extensions
 
         /// <summary>
         /// Creates a <see cref="Location"/> that spans the regex <paramref name="match"/> within
-        /// the source text of <paramref name="argument"/>.
+        /// the source text of <paramref name="expression"/>.
         /// </summary>
-        internal static Location CreateMatchLocation(this ArgumentSyntax argument, SyntaxTree syntaxTree, Match match)
+        internal static Location CreateMatchLocation(this ExpressionSyntax expression, SyntaxTree syntaxTree, Match match)
         {
-            var matchStart = argument.SpanStart + match.Index;
+            var matchStart = expression.SpanStart + match.Index;
             var matchSpan = new TextSpan(matchStart, match.Length);
             return Location.Create(syntaxTree, matchSpan);
+        }
+
+        /// <summary>
+        /// If <paramref name="expression"/> is a reference to a local variable initialised with a
+        /// string or interpolated-string literal, sets <paramref name="resolvedExpression"/> to that
+        /// literal and returns <see langword="true"/>; otherwise returns <see langword="false"/>.
+        /// </summary>
+        internal static bool TryResolveToStringLiteral(
+            this ExpressionSyntax expression,
+            SemanticModel semanticModel,
+            out ExpressionSyntax resolvedExpression)
+        {
+            resolvedExpression = null;
+
+            if (!(expression is IdentifierNameSyntax))
+            {
+                return false;
+            }
+
+            var symbol = semanticModel.GetSymbolInfo(expression).Symbol as ILocalSymbol;
+            if (symbol == null)
+            {
+                return false;
+            }
+
+            var declarator = symbol.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax() as VariableDeclaratorSyntax;
+
+            var initValue = declarator?.Initializer?.Value;
+            if (initValue is LiteralExpressionSyntax || initValue is InterpolatedStringExpressionSyntax)
+            {
+                resolvedExpression = initValue;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesMustBeUsed/LogMessagesNamedPropertiesMustBeUsedAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesMustBeUsed/LogMessagesNamedPropertiesMustBeUsedAnalyzer.cs
@@ -18,9 +18,9 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesMustBeU
         private const string MessageFormat = "Log message property '{0}' is a positional parameter";
         private const string Description = "Do not use positional parameters in log message templates. Use named properties instead.";
 
-        private const string InvalidPositionalPropertyPattern = @"(?<!\{)\{(?!\{)(@?\d+(?=[}:,])[^{}]*)\}(?!\})";
+        private const string InvalidPositionalPropertyPattern = @"(?<!\{)\{(?!\{)(?'propertyName'@?\d+(?=[}:,])[^{}]*)\}(?!\})";
 
-        private const string InvalidPositionalPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(@?\d+(?=[}:,])[^{}]*)\}\}(?!\})";
+        private const string InvalidPositionalPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(?'propertyName'@?\d+(?=[}:,])[^{}]*)\}\}(?!\})";
 
         private const string LoggerMessageParameterName = "message";
 
@@ -50,8 +50,13 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesMustBeU
                 return;
             }
 
-            var messageParameterValue = messageArgument.ToString();
-            var pattern = messageArgument.Expression is InterpolatedStringExpressionSyntax
+            // If the argument is a local variable, try to resolve it back to its initializer string literal.
+            var messageExpression = messageArgument.Expression.TryResolveToStringLiteral(nodeAnalysisContext.SemanticModel, out var resolvedExpression)
+                ? resolvedExpression
+                : messageArgument.Expression;
+
+            var messageParameterValue = messageExpression.ToString();
+            var pattern = messageExpression is InterpolatedStringExpressionSyntax
                 ? InvalidPositionalPropertyPatternInterpolated
                 : InvalidPositionalPropertyPattern;
 
@@ -60,8 +65,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesMustBeU
 
             foreach (Match namedProperty in invalidNamedProperties)
             {
-                var propertyName = namedProperty.Groups[1].Value;
-                var location = messageArgument.CreateMatchLocation(nodeAnalysisContext.Node.SyntaxTree, namedProperty);
+                var propertyName = namedProperty.Groups["propertyName"].Value;
+                var location = messageExpression.CreateMatchLocation(messageExpression.SyntaxTree, namedProperty);
                 var diagnostic = Diagnostic.Create(Rule, location, propertyName);
                 nodeAnalysisContext.ReportDiagnostic(diagnostic);
             }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesMustBeUsed/LogMessagesNamedPropertiesMustBeUsedAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesMustBeUsed/LogMessagesNamedPropertiesMustBeUsedAnalyzer.cs
@@ -1,33 +1,31 @@
 ﻿using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using Audacia.CodeAnalysis.Analyzers.Common;
+using Audacia.CodeAnalysis.Analyzers.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Audacia.CodeAnalysis.Analyzers.Common;
-using Audacia.CodeAnalysis.Analyzers.Extensions;
 
-namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalCase
+namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesMustBeUsed
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public sealed class LogMessagesNamedPropertiesPascalCaseAnalyzer : DiagnosticAnalyzer
+    public sealed class LogMessagesNamedPropertiesMustBeUsedAnalyzer : DiagnosticAnalyzer
     {
-        public const string Id = DiagnosticId.LogMessagesNamedPropertiesPascalCase;
+        public const string Id = DiagnosticId.LogMessagesNamedPropertiesMustBeUsed;
 
-        private const string Title = "Log message property is not in PascalCase";
-        private const string MessageFormat = "Log message property '{0}' does not use PascalCase";
-        private const string Description = "When using log message named properties, ensure they are in PascalCase.";
+        private const string Title = "Log message template format uses positional parameters";
+        private const string MessageFormat = "Log message property '{0}' is a positional parameter";
+        private const string Description = "Do not use positional parameters in log message templates. Use named properties instead.";
 
-        private const string InvalidNamedPropertyPattern = @"(?<!\{)\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])([^{}:]+)[^{}]*\}(?!\})";
+        private const string InvalidPositionalPropertyPattern = @"(?<!\{)\{(?!\{)(@?\d+(?=[}:,])[^{}]*)\}(?!\})";
 
-        // In interpolated strings, log template placeholders are double-braced in source: {{Name}} => {Name} at runtime.
-        // This pattern matches {{name}} but not {{{{...}}}} (which are escaped literal braces).
-        private const string InvalidNamedPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])([^{}:]+)[^{}]*\}\}(?!\})";
+        private const string InvalidPositionalPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(@?\d+(?=[}:,])[^{}]*)\}\}(?!\})";
 
         private const string LoggerMessageParameterName = "message";
 
         private static readonly DiagnosticDescriptor Rule
-            = new DiagnosticDescriptor(Id, Title, MessageFormat, DiagnosticCategory.Naming, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
+            = new DiagnosticDescriptor(Id, Title, MessageFormat, DiagnosticCategory.Usage, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: Description);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
@@ -54,10 +52,10 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalC
 
             var messageParameterValue = messageArgument.ToString();
             var pattern = messageArgument.Expression is InterpolatedStringExpressionSyntax
-                ? InvalidNamedPropertyPatternInterpolated
-                : InvalidNamedPropertyPattern;
+                ? InvalidPositionalPropertyPatternInterpolated
+                : InvalidPositionalPropertyPattern;
 
-            // Use regex to find all named properties in the message template that do not follow PascalCase
+            // Use regex to find all named properties which are positional identifiers
             var invalidNamedProperties = Regex.Matches(messageParameterValue, pattern);
 
             foreach (Match namedProperty in invalidNamedProperties)

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesPascalCase/LogMessagesNamedPropertiesPascalCaseAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNamedPropertiesPascalCase/LogMessagesNamedPropertiesPascalCaseAnalyzer.cs
@@ -18,12 +18,11 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalC
         private const string MessageFormat = "Log message property '{0}' does not use PascalCase";
         private const string Description = "When using log message named properties, ensure they are in PascalCase.";
 
-        private const string InvalidNamedPropertyPattern = @"(?<!\{)\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])([^{}:]+)[^{}]*\}(?!\})";
+        private const string InvalidNamedPropertyPattern = @"(?<!\{)\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])(?'propertyName'[^{}:]+)[^{}]*\}(?!\})";
 
         // In interpolated strings, log template placeholders are double-braced in source: {{Name}} => {Name} at runtime.
         // This pattern matches {{name}} but not {{{{...}}}} (which are escaped literal braces).
-        private const string InvalidNamedPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])([^{}:]+)[^{}]*\}\}(?!\})";
-
+        private const string InvalidNamedPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(?!(?:\d+|@?[A-Z][a-zA-Z0-9]*)[}:])(?'propertyName'[^{}:]+)[^{}]*\}\}(?!\})";
         private const string LoggerMessageParameterName = "message";
 
         private static readonly DiagnosticDescriptor Rule
@@ -52,8 +51,13 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalC
                 return;
             }
 
-            var messageParameterValue = messageArgument.ToString();
-            var pattern = messageArgument.Expression is InterpolatedStringExpressionSyntax
+            // If the argument is a local variable, try to resolve it back to its initializer string literal.
+            var messageExpression = messageArgument.Expression.TryResolveToStringLiteral(nodeAnalysisContext.SemanticModel, out var resolvedExpression)
+                ? resolvedExpression
+                : messageArgument.Expression;
+
+            var messageParameterValue = messageExpression.ToString();
+            var pattern = messageExpression is InterpolatedStringExpressionSyntax
                 ? InvalidNamedPropertyPatternInterpolated
                 : InvalidNamedPropertyPattern;
 
@@ -62,8 +66,8 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalC
 
             foreach (Match namedProperty in invalidNamedProperties)
             {
-                var propertyName = namedProperty.Groups[1].Value;
-                var location = messageArgument.CreateMatchLocation(nodeAnalysisContext.Node.SyntaxTree, namedProperty);
+                var propertyName = namedProperty.Groups["propertyName"].Value;
+                var location = messageExpression.CreateMatchLocation(messageExpression.SyntaxTree, namedProperty);
                 var diagnostic = Diagnostic.Create(Rule, location, propertyName);
                 nodeAnalysisContext.ReportDiagnostic(diagnostic);
             }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNoDuplicateParameters/LogMessagesNoDuplicateParametersAnalyzer.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Rules/LogMessagesNoDuplicateParameters/LogMessagesNoDuplicateParametersAnalyzer.cs
@@ -22,11 +22,11 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNoDuplicateParameters
 
         // Matches named (non-positional) log message properties in regular strings, capturing the property name in group 1.
         // Excludes escaped braces ({{...}}) and positional placeholders ({0}, {1:N0}).
-        private const string NamedPropertyPattern = @"(?<!\{)\{(?!\{)(@?\D[^:{}]*)(?:[^{}]*)?\}(?!\})";
+        private const string NamedPropertyPattern = @"(?<!\{)\{(?!\{)(?'propertyName'@?\D[^:{}]*)(?:[^{}]*)?\}(?!\})";
 
         // In interpolated strings, log template placeholders are double-braced in source: {{Name}} => {Name} at runtime.
         // This pattern matches {{name}} but not {{{{...}}}} (which are escaped literal braces).
-        private const string NamedPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(@?\D[^:{}]*)(?:[^{}]*)?\}\}(?!\})";
+        private const string NamedPropertyPatternInterpolated = @"(?<!\{)\{\{(?!\{)(?'propertyName'@?\D[^:{}]*)(?:[^{}]*)?\}\}(?!\})";
 
         private const string LoggerMessageParameterName = "message";
 
@@ -56,8 +56,13 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNoDuplicateParameters
                 return;
             }
 
-            var messageParameterValue = messageArgument.ToString();
-            var pattern = messageArgument.Expression is InterpolatedStringExpressionSyntax
+            // If the argument is a local variable, try to resolve it back to its initializer string literal.
+            var messageExpression = messageArgument.Expression.TryResolveToStringLiteral(nodeAnalysisContext.SemanticModel, out var resolvedExpression)
+                ? resolvedExpression
+                : messageArgument.Expression;
+
+            var messageParameterValue = messageExpression.ToString();
+            var pattern = messageExpression is InterpolatedStringExpressionSyntax
                 ? NamedPropertyPatternInterpolated
                 : NamedPropertyPattern;
 
@@ -69,11 +74,11 @@ namespace Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNoDuplicateParameters
 
             foreach (Match namedProperty in allNamedProperties)
             {
-                var propertyName = namedProperty.Groups[1].Value;
+                var propertyName = namedProperty.Groups["propertyName"].Value;
 
                 if (!seenNames.Add(propertyName))
                 {
-                    var location = messageArgument.CreateMatchLocation(nodeAnalysisContext.Node.SyntaxTree, namedProperty);
+                    var location = messageExpression.CreateMatchLocation(messageExpression.SyntaxTree, namedProperty);
                     nodeAnalysisContext.ReportDiagnostic(Diagnostic.Create(Rule, location, propertyName));
                 }
             }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesMustBeUsedAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesMustBeUsedAnalyzerTests.cs
@@ -1,23 +1,21 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesPascalCase;
+using Audacia.CodeAnalysis.Analyzers.Rules.LogMessagesNamedPropertiesMustBeUsed;
 using Audacia.CodeAnalysis.Analyzers.Test.Base;
 using Audacia.CodeAnalysis.Analyzers.Test.Helpers;
-using System;
 
 namespace Audacia.CodeAnalysis.Analyzers.Test.Rules
 {
     [TestClass]
-    public class LogMessagesNamedPropertiesPascalCaseAnalyzerTests : DiagnosticVerifier
+    public class LogMessagesNamedPropertiesMustBeUsedAnalyzerTests : DiagnosticVerifier
     {
         private DiagnosticResult BuildExpectedResult(int lineNumber, int column, string propertyName)
         {
             return new DiagnosticResult
             {
-                Id = LogMessagesNamedPropertiesPascalCaseAnalyzer.Id,
-                Message = $"Log message property '{propertyName}' does not use PascalCase",
+                Id = LogMessagesNamedPropertiesMustBeUsedAnalyzer.Id,
+                Message = $"Log message property '{propertyName}' is a positional parameter",
                 Severity = DiagnosticSeverity.Warning,
                 Locations =
                 [
@@ -28,7 +26,7 @@ namespace Audacia.CodeAnalysis.Analyzers.Test.Rules
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
-            return new LogMessagesNamedPropertiesPascalCaseAnalyzer();
+            return new LogMessagesNamedPropertiesMustBeUsedAnalyzer();
         }
 
         [TestMethod]
@@ -36,7 +34,6 @@ namespace Audacia.CodeAnalysis.Analyzers.Test.Rules
         {
             var test = @"
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -52,13 +49,11 @@ class ClassName
         {
             var test = @"
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         var x = 1 + 2;
@@ -71,15 +66,20 @@ class ClassName
         [TestMethod]
         [DataRow("CalculatedValue")]
         [DataRow("@CalculatedValue")]
+        [DataRow("calculated_value")]
+        [DataRow("calculated-value")]
+        [DataRow("CalculatedValue1")]
         [DataRow("CLCValue")]
-        [DataRow("X")]
+        [DataRow("x")]
+        [DataRow("0calculatedValue")]
+        [DataRow("0calculatedValue:N0")]
+        [DataRow("Calculated:c")]
         [DataRow("")]
-        public void No_Diagnostics_When_Log_Message_Properties_Pascal_Case(string propertyName)
+        public void No_Diagnostics_When_Log_Message_Properties_Not_Positional(string propertyName)
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -89,21 +89,19 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {" + propertyName + @"}"", x);
+        logger.LogInformation(""123: {" + propertyName + @"}"", x);
     }
 }";
             VerifyNoDiagnostic(test);
         }
 
         [TestMethod]
-        public void No_Diagnostics_When_Log_Message_Properties_Pascal_Case_With_Escaped_Braces()
+        public void No_Diagnostics_When_Log_Message_Properties_Not_Positional_With_Escaped_Braces()
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -113,21 +111,27 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(""{{Calculated value}}: {CalculatedValue}"", x);
+        logger.LogInformation(""{{123}}: {CalculatedValue}"", x);
     }
 }";
             VerifyNoDiagnostic(test);
         }
 
         [TestMethod]
-        public void No_Diagnostics_When_Log_Message_Properties_Pascal_Case_With_Interpolated_Placeholders()
+        [DataRow("CalculatedValue")]
+        [DataRow("@CalculatedValue")]
+        [DataRow("CLCValue")]
+        [DataRow("x")]
+        [DataRow("0calculatedValue")]
+        [DataRow("0calculatedValue:N0")]
+        [DataRow("Calculated:c")]
+        [DataRow("")]
+        public void No_Diagnostics_When_Log_Message_Properties_Not_Positional_With_Interpolated_Placeholders(string propertyName)
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -137,35 +141,8 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation($""{{{{Calculated value}}}}: {{CalculatedValue}}"", x);
-    }
-}";
-            VerifyNoDiagnostic(test);
-        }
-
-        [TestMethod]
-        public void No_Diagnostics_When_Log_Message_Properties_Pascal_Case_With_Formatting()
-        {
-            var test = @"
-using System;
-using Microsoft.Extensions.Logging;
-namespace ConsoleApplication;
-
-class ClassName
-{
-    static void Main(string[] args)
-    {
-    }
-    
-    private void Method()
-    {
-        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
-        var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {CalculatedValue:N0}"", x);
-        logger.LogInformation(""Date: {DateNow:MMMM dd, yyyy}"", DateTime.UtcNow);
+        logger.LogInformation($""{{{{123}}}}: {{" + propertyName + @"}}"", x);
     }
 }";
             VerifyNoDiagnostic(test);
@@ -177,7 +154,6 @@ class ClassName
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -187,12 +163,10 @@ class ClassName
     private void Method()
     {
         var logger = new CustomLogger();
-
         var x = 1 + 2;
         logger.LogInformation(""Calculated value: {calculatedValue}"", x);
     }
 }
-
 class CustomLogger
 {
     public void LogInformation(string message, params object[] args)
@@ -204,62 +178,24 @@ class CustomLogger
         }
 
         [TestMethod]
-        public void Diagnostic_When_Log_Method_Called_On_Type_Implementing_ILogger()
+        public void No_Diagnostics_When_Log_Method_Called_On_Type_Implementing_ILogger_With_No_Positional_Properties()
         {
             var test = @"
 using System;
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         ILogger logger = new CustomLogger();
-
         var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {calculatedValue}"", x);
+        logger.LogInformation(""123: {CalculatedValue}"", x);
     }
 }
-
-class CustomLogger : ILogger
-{
-    public IDisposable BeginScope<TState>(TState state) => null;
-    public bool IsEnabled(LogLevel logLevel) => true;
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
-}";
-
-            var expected = BuildExpectedResult(17, 50, "calculatedValue");
-            VerifyDiagnostic(test, expected);
-        }
-
-        [TestMethod]
-        public void No_Diagnostics_When_Log_Method_Called_On_Type_Implementing_ILogger_With_Pascal_Case()
-        {
-            var test = @"
-using System;
-using Microsoft.Extensions.Logging;
-namespace ConsoleApplication;
-
-class ClassName
-{
-    static void Main(string[] args)
-    {
-    }
-
-    private void Method()
-    {
-        ILogger logger = new CustomLogger();
-
-        var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {CalculatedValue}"", x);
-    }
-}
-
 class CustomLogger : ILogger
 {
     public IDisposable BeginScope<TState>(TState state) => null;
@@ -276,7 +212,6 @@ class CustomLogger : ILogger
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -286,81 +221,77 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(args: new []{ x }, message: ""Message: {CalculatedValue}"");
+        logger.LogInformation(args: new []{ x }, message: ""Message: {Value}"");
     }
 }";
             VerifyNoDiagnostic(test);
         }
 
         [TestMethod]
-        public void No_Diagnostics_When_Log_Message_Uses_Positional_Properties()
+        public void Diagnostic_When_Log_Method_Called_On_Type_Implementing_ILogger()
         {
             var test = @"
+using System;
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-    
     private void Method()
     {
-        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
+        ILogger logger = new CustomLogger();
         var x = 1 + 2;
-        var y = x + 3;
-        logger.LogInformation(""Calculated value: {0} {1:N0}"", x, y);
+        logger.LogInformation(""Calculated value: {0}"", x);
     }
+}
+class CustomLogger : ILogger
+{
+    public IDisposable BeginScope<TState>(TState state) => null;
+    public bool IsEnabled(LogLevel logLevel) => true;
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) { }
 }";
 
-            VerifyNoDiagnostic(test);
+            var expected = BuildExpectedResult(14, 50, "0");
+            VerifyDiagnostic(test, expected);
         }
 
         [TestMethod]
-        [DataRow("calculatedValue")]
-        [DataRow("@calculatedValue")]
-        [DataRow("calculated-value")]
-        [DataRow("Calculated_Value")]
-        [DataRow("Calculated!Value")]
-        [DataRow("x")]
-        [DataRow(" CalculatedValue ")]
-        [DataRow("1CalculatedValue")]
-        public void Diagnostic_When_Log_Message_Property_Not_Pascal_Case(string propertyName)
+        [DataRow("0")]
+        [DataRow("@0")]
+        [DataRow("123")]
+        [DataRow("0:c")]
+        [DataRow("0:N0")]
+        public void Diagnostic_When_Log_Message_Uses_Positional_Property(string propertyName)
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
         logger.LogInformation(""Calculated value: {" + propertyName + @"}"", x);
     }
 }";
 
-            var expected = BuildExpectedResult(16, 50, propertyName);
+            var expected = BuildExpectedResult(13, 50, propertyName);
             VerifyDiagnostic(test, expected);
         }
 
         [TestMethod]
-        public void Diagnostics_When_Log_Message_Properties_Not_Pascal_Case_With_Escaped_Braces()
+        public void Diagnostics_When_Log_Message_Uses_Positional_Property_With_Escaped_Braces()
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -370,37 +301,39 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(""{{Calculated value}}: {calculatedValue}"", x);
+        logger.LogInformation(""{{Calculated value}}: {0}"", x);
     }
 }";
-            var expected = BuildExpectedResult(16, 54, "calculatedValue");
+            var expected = BuildExpectedResult(14, 54, "0");
             VerifyDiagnostic(test, expected);
         }
 
         [TestMethod]
-        public void Diagnostics_When_Log_Message_Properties_Not_Pascal_Case_With_Interpolated_Placeholders()
+        [DataRow("0")]
+        [DataRow("@0")]
+        [DataRow("123")]
+        [DataRow("0:c")]
+        [DataRow("0:N0")]
+        public void Diagnostic_When_Log_Message_Uses_Positional_Property_With_Interpolated_Placeholders(string propertyName)
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-    
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation($""{{{{Calculated value}}}}: {{calculatedValue}}"", x);
+        logger.LogInformation($""{{{{Calculated value}}}}: {{" + propertyName + @"}}"", x);
     }
 }";
-            var expected = BuildExpectedResult(16, 59, "calculatedValue");
+
+            var expected = BuildExpectedResult(13, 59, propertyName);
             VerifyDiagnostic(test, expected);
         }
 
@@ -445,84 +378,75 @@ class ClassName
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger." + overloadPrefix + @"""Calculated value: {calculatedValue}"", x);
+        logger." + overloadPrefix + @"""Calculated value: {0}"", x);
     }
 }";
-            var logger = (new LoggerFactory()).CreateLogger<LogMessagesNamedPropertiesPascalCaseAnalyzerTests>();
 
-
-            var expected = BuildExpectedResult(16, 35 + overloadPrefix.Length, "calculatedValue");
+            var expected = BuildExpectedResult(13, 35 + overloadPrefix.Length, "0");
             VerifyDiagnostic(test, expected);
         }
 
+
         [TestMethod]
-        public void Multiple_Diagnostics_When_Log_Message_Properties_Not_Pascal_Case()
+        public void Multiple_Diagnostics_When_Log_Message_Properties_Are_Positional()
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {valueOne} and {Value_Two}"", x);
+        var y = x + 3;
+        logger.LogInformation(""Calculated value: {0} and {1}"", x, y);
     }
 }";
 
-            var expectedOne = BuildExpectedResult(16, 50, "valueOne");
-            var expectedTwo = BuildExpectedResult(16, 65, "Value_Two");
+            var expectedOne = BuildExpectedResult(14, 50, "0");
+            var expectedTwo = BuildExpectedResult(14, 58, "1");
             VerifyDiagnostic(test, expectedOne, expectedTwo);
         }
 
         [TestMethod]
-        public void Multiple_Diagnostics_When_Multiple_Log_Message_Properties_Not_Pascal_Case()
+        public void Multiple_Diagnostics_When_Multiple_Log_Message_Properties_Are_Positional()
         {
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
     {
     }
-
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(""Calculated value: {valueOne} and {Value_Two}"", x);
-        logger.LogDebug(""Calculated value: {value-three} and {Value!Four}"", x);
+        var y = x + 3;
+        logger.LogInformation(""Calculated value: {0} and {1}"", x, y);
+        logger.LogDebug(""Calculated value: {value} and {0}"", x, y);
     }
 }";
 
-            var expectedOne = BuildExpectedResult(16, 50, "valueOne");
-            var expectedTwo = BuildExpectedResult(16, 65, "Value_Two");
-            var expectedThree = BuildExpectedResult(17, 44, "value-three");
-            var expectedFour = BuildExpectedResult(17, 62, "Value!Four");
+            var expectedOne = BuildExpectedResult(14, 50, "0");
+            var expectedTwo = BuildExpectedResult(14, 58, "1");
+            var expectedThree = BuildExpectedResult(15, 56, "0");
 
-            VerifyDiagnostic(test, expectedOne, expectedTwo, expectedThree, expectedFour);
+            VerifyDiagnostic(test, expectedOne, expectedTwo, expectedThree);
         }
 
         [TestMethod]
@@ -531,7 +455,6 @@ class ClassName
             var test = @"
 using Microsoft.Extensions.Logging;
 namespace ConsoleApplication;
-
 class ClassName
 {
     static void Main(string[] args)
@@ -541,12 +464,11 @@ class ClassName
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
-
         var x = 1 + 2;
-        logger.LogInformation(args: new []{ x }, message: ""Message: {calculatedValue}"");
+        logger.LogInformation(args: new []{ x }, message: ""Message: {0}"");
     }
 }";
-            var expected = BuildExpectedResult(16, 69, "calculatedValue");
+            var expected = BuildExpectedResult(14, 69, "0");
             VerifyDiagnostic(test, expected);
         }
     }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesMustBeUsedAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesMustBeUsedAnalyzerTests.cs
@@ -460,7 +460,7 @@ class ClassName
     static void Main(string[] args)
     {
     }
-    
+
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
@@ -469,6 +469,101 @@ class ClassName
     }
 }";
             var expected = BuildExpectedResult(14, 69, "0");
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_When_Log_Message_Uses_Positional_Property_In_Interpolated_String_With_Mixed_Content()
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        logger.LogInformation($""Calculated value: {{0}} for {x}"", x);
+    }
+}";
+            var expected = BuildExpectedResult(14, 51, "0");
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_When_Log_Message_Is_Variable_With_Positional_Property()
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        var message = ""Calculated value: {0}"";
+        logger.LogInformation(message, x);
+    }
+}";
+            var expected = BuildExpectedResult(14, 42, "0");
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        [DataRow("0,10")]
+        [DataRow("0,10:N0")]
+        public void Diagnostic_When_Log_Message_Uses_Positional_Property_With_Alignment_Or_Format(string propertyName)
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        logger.LogInformation(""Value: {" + propertyName + @"}"", x);
+    }
+}";
+            var expected = BuildExpectedResult(14, 39, propertyName);
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_When_Log_Message_Uses_Positional_Property_With_Named_Args()
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        logger.LogInformation(message: ""Calculated value: {0}"", args: new[] { x });
+    }
+}";
+            var expected = BuildExpectedResult(14, 59, "0");
             VerifyDiagnostic(test, expected);
         }
     }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesPascalCaseAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNamedPropertiesPascalCaseAnalyzerTests.cs
@@ -537,7 +537,7 @@ class ClassName
     static void Main(string[] args)
     {
     }
-    
+
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
@@ -547,6 +547,31 @@ class ClassName
     }
 }";
             var expected = BuildExpectedResult(16, 69, "calculatedValue");
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_When_Log_Message_Is_Variable_With_Non_PascalCase_Property()
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        var message = ""Calculated value: {calculatedValue}"";
+        logger.LogInformation(message, x);
+    }
+}";
+            var expected = BuildExpectedResult(15, 42, "calculatedValue");
             VerifyDiagnostic(test, expected);
         }
     }

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNoDuplicateParametersAnalyzerTests.cs
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/tests/Audacia.CodeAnalysis.Analyzers.Test/Rules/LogMessagesNoDuplicateParametersAnalyzerTests.cs
@@ -565,7 +565,7 @@ class ClassName
     static void Main(string[] args)
     {
     }
-    
+
     private void Method()
     {
         var logger = (new LoggerFactory()).CreateLogger<ClassName>();
@@ -577,6 +577,31 @@ class ClassName
     }
 }";
             var expected = BuildExpectedResult(18, 84, "Value");
+            VerifyDiagnostic(test, expected);
+        }
+
+        [TestMethod]
+        public void Diagnostic_When_Log_Message_Is_Variable_With_Duplicate_Property()
+        {
+            var test = @"
+using Microsoft.Extensions.Logging;
+namespace ConsoleApplication;
+
+class ClassName
+{
+    static void Main(string[] args)
+    {
+    }
+
+    private void Method()
+    {
+        var logger = (new LoggerFactory()).CreateLogger<ClassName>();
+        var x = 1 + 2;
+        var message = ""Calculated value: {Value} and {Value}"";
+        logger.LogInformation(message, x, x);
+    }
+}";
+            var expected = BuildExpectedResult(15, 54, "Value");
             VerifyDiagnostic(test, expected);
         }
     }


### PR DESCRIPTION
### Version changed and CHANGELOG updated- ❎ No version change required

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ✔ Tests added/updated for all new and modified code

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ❎ No new/upgraded dependencies

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR