### PR TITLE
feat: Publish version 1.13.0 of the Audacia.CodeAnalysis.Analyzers package

### DIFF
--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/CHANGELOG.md
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/CHANGELOG.md
@@ -1,6 +1,6 @@
 ﻿# CHANGELOG
 
-# TBC - TBC
+# 1.13.0 - 2026-06-04
 ### Added
 - Added new rule "AssertionScopeForMultipleAssertions" (ACL1019).
     - This rule checks that if there are more than 2 assertions within a test method then they are wrapped in an AssertionScope. This provides better failure messages and allows all assertions to be evaluated even if one fails.

--- a/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
+++ b/dotnet-roslyn/analyzers/Audacia.CodeAnalysis.Analyzers/src/Audacia.CodeAnalysis.Analyzers/Audacia.CodeAnalysis.Analyzers.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>1.12.1</Version>
+        <Version>1.13.0</Version>
         <PackageId>Audacia.CodeAnalysis.Analyzers</PackageId>
         <Authors>Audacia</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG

### Code ready for review
- ❎ No code changes (e.g. just a documentation change)

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ❎ No new/upgraded dependencies

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR