### PR TITLE
feat: Add Microsoft.VisualStudio.Threading.Analyzers package and configure default severities

### DIFF
--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/Audacia.CodeAnalysis.AspNetCore.globalconfig
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.AspNetCore/Audacia.CodeAnalysis.AspNetCore.globalconfig
@@ -102,3 +102,12 @@ dotnet_diagnostic.ACL1015.severity = warning
 
 # Controller action should return TypedResults instead of IActionResult
 dotnet_diagnostic.ACL1016.severity = warning
+
+# VSTHRD012: Provide JoinableTaskFactory where allowed
+dotnet_diagnostic.VSTHRD012.severity = none
+
+# VSTHRD003: Avoid awaiting foreign Tasks
+dotnet_diagnostic.VSTHRD003.severity = none
+
+# VSTHRD010: Invoke single-threaded types on Main thread
+dotnet_diagnostic.VSTHRD010.severity = none

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis.TestProjects/Audacia.CodeAnalysis.TestProjects.globalconfig
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis.TestProjects/Audacia.CodeAnalysis.TestProjects.globalconfig
@@ -29,3 +29,6 @@ dotnet_diagnostic.CA1707.severity = none
 
 # [NAMING] Asynchronous method name should end with 'Async' ** Suppress as we don't want to suffix test methods ***
 dotnet_diagnostic.RCS1046.severity = none
+
+# VSTHRD200: Use `Async` naming convention
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Audacia.CodeAnalysis.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="CSharpGuidelinesAnalyzer" Version="3.8.5" />
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <PackageReference Include="IDisposableAnalyzers" Version="4.0.8" />
+	<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
@@ -25,17 +26,13 @@
     <None Include="../../../package-icon.png" Pack="true" PackagePath="\" />
 
     <!-- Global config: placed in buildTransitive/ alongside the .props file -->
-    <None Include="Base/Audacia.CodeAnalysis.globalconfig"
-          Pack="true"
-          PackagePath="buildTransitive\" />
+    <None Include="Base/Audacia.CodeAnalysis.globalconfig" Pack="true" PackagePath="buildTransitive\" />
 
     <!-- MSBuild props: auto-imported by NuGet for direct consumers -->
-    <None Include="buildTransitive/Audacia.CodeAnalysis.props"
-          Pack="true"
-          PackagePath="buildTransitive\" />
+    <None Include="buildTransitive/Audacia.CodeAnalysis.props" Pack="true" PackagePath="buildTransitive\" />
 
-    <None Include="buildTransitive/Audacia.CodeAnalysis.targets"
-          Pack="true"
-          PackagePath="buildTransitive\" />
+	  <None Include="buildTransitive/Audacia.CodeAnalysis.targets" Pack="true" PackagePath="buildTransitive\" />
+
+	  <None Include="buildTransitive/vs-threading.LegacyThreadSwitchingMembers.txt" Pack="true" PackagePath="buildTransitive\" />
   </ItemGroup>
 </Project>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Base/Audacia.CodeAnalysis.globalconfig
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Base/Audacia.CodeAnalysis.globalconfig
@@ -2809,3 +2809,75 @@ dotnet_diagnostic.IDE1005.severity = warning
 
 # Naming styles
 dotnet_diagnostic.IDE1006.severity = warning
+
+# Avoid legacy thread switching Methods
+dotnet_diagnostic.VSTHRD001.severity = warning
+
+# Avoid problematic synchronous waits
+dotnet_diagnostic.VSTHRD002.severity = warning
+
+# Avoid awaiting foreign Tasks
+dotnet_diagnostic.VSTHRD003.severity = warning
+
+# Await SwitchToMainThreadAsync
+dotnet_diagnostic.VSTHRD004.severity = error
+
+# Invoke single-threaded types on Main thread
+dotnet_diagnostic.VSTHRD010.severity = warning
+
+# Use AsyncLazy<T>
+dotnet_diagnostic.VSTHRD011.severity = error
+
+# Provide JoinableTaskFactory where allowed
+dotnet_diagnostic.VSTHRD012.severity = warning
+
+# Avoid async void methods
+dotnet_diagnostic.VSTHRD100.severity = warning
+
+# Avoid unsupported async delegates
+dotnet_diagnostic.VSTHRD101.severity = warning
+
+# Implement internal logic asynchronously
+dotnet_diagnostic.VSTHRD102.severity = suggestion
+
+# Call async methods when in an async method
+dotnet_diagnostic.VSTHRD103.severity = warning
+
+# Offer async option
+dotnet_diagnostic.VSTHRD104.severity = suggestion
+
+# Avoid method overloads that assume TaskScheduler.Current
+dotnet_diagnostic.VSTHRD105.severity = warning
+
+# Use InvokeAsync to raise async events
+dotnet_diagnostic.VSTHRD106.severity = warning
+
+# Await Task within using expression
+dotnet_diagnostic.VSTHRD107.severity = error
+
+# Assert thread affinity unconditionally
+dotnet_diagnostic.VSTHRD108.severity = warning
+
+# Switch instead of assert in async methods
+dotnet_diagnostic.VSTHRD109.severity = error
+
+# Observe result of async calls
+dotnet_diagnostic.VSTHRD110.severity = warning
+
+# Use .ConfigureAwait(bool)
+dotnet_diagnostic.VSTHRD111.severity = none
+
+# Implement System.IAsyncDisposable
+dotnet_diagnostic.VSTHRD112.severity = suggestion
+
+# Check for System.IAsyncDisposable
+dotnet_diagnostic.VSTHRD113.severity = suggestion
+
+# Avoid returning null from a Task-returning method.
+dotnet_diagnostic.VSTHRD114.severity = warning
+
+# Avoid creating a JoinableTaskContext with an explicit null SynchronizationContext
+dotnet_diagnostic.VSTHRD115.severity = warning
+
+# Use Async naming convention
+dotnet_diagnostic.VSTHRD200.severity = warning

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- No new functionality added
+- Added analyzers with default severities from ([Microsoft.VisualStudio.Threading.Analyzers](https://microsoft.github.io/vs-threading/analyzers/index.html))
 
 ### Changed
 

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/README.md
@@ -135,6 +135,11 @@ All rules are prefixed with `DOC`.
 
 All rules are prefixed `EF`.
 
+### Threading Analyzers
+[Microsoft.VisualStudio.Threading.Analyzers](https://microsoft.github.io/vs-threading/analyzers/index.html) provides analyzers for potential issues regarding threading and async coding.
+
+All rules are prefixed with `VSTHRD`.
+
 # Contributing
 
 We welcome contributions! Please feel free to check our [Contribution Guidelines](https://github.com/audaciaconsulting/.github/blob/main/CONTRIBUTING.md) for feature requests, issue reporting and guidelines.

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/buildTransitive/Audacia.CodeAnalysis.targets
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/buildTransitive/Audacia.CodeAnalysis.targets
@@ -2,6 +2,7 @@
   <Target Name="AddGlobalAnalyzerConfigForPackage_AudaciaCodeAnalysis" BeforeTargets="CoreCompile">
     <ItemGroup>
       <EditorConfigFiles Include="$(MSBuildThisFileDirectory)Audacia.CodeAnalysis.globalconfig" Condition="Exists('$(MSBuildThisFileDirectory)Audacia.CodeAnalysis.globalconfig')" />
+	  <AdditionalFiles Include="$(MSBuildThisFileDirectory)vs-threading.LegacyThreadSwitchingMembers.txt" Condition="Exists('$(MSBuildThisFileDirectory)vs-threading.LegacyThreadSwitchingMembers.txt')" />
     </ItemGroup>
   </Target>
 </Project>

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/buildTransitive/vs-threading.LegacyThreadSwitchingMembers.txt
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/buildTransitive/vs-threading.LegacyThreadSwitchingMembers.txt
@@ -1,0 +1,2 @@
+[System.Windows.Threading.Dispatcher]::Invoke
+[Microsoft.VisualStudio.Shell.ThreadHelper]::Invoke


### PR DESCRIPTION
The default severities can be found here https://microsoft.github.io/vs-threading/analyzers/index.html and for different types of apps, here https://github.com/microsoft/vs-threading/blob/main/doc/editorconfigs/README.md

### Version changed and CHANGELOG updated
- ❎ No version change required

### Code ready for review
- ❎ No code changes (e.g. just a documentation change)

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ✔ Documentation updated to reflect the changes made

### Dependency licenses
- ✔ Licenses of new/upgraded dependencies checked, with no copyleft dependencies introduced

### Work item linked
- ✔ The Azure DevOps work item has been linked to the PR