### PR TITLE
fix: disable VSTHRD200 as duplicate Async suffix analyzer

### DIFF
--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/Base/Audacia.CodeAnalysis.globalconfig
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/Base/Audacia.CodeAnalysis.globalconfig
@@ -2903,5 +2903,5 @@ dotnet_diagnostic.VSTHRD114.severity = warning
 # Avoid creating a JoinableTaskContext with an explicit null SynchronizationContext
 dotnet_diagnostic.VSTHRD115.severity = warning
 
-# Use Async naming convention
-dotnet_diagnostic.VSTHRD200.severity = warning
+# Use Async naming convention *** Suppress as covered by RCS1046 normally and ACL1005 in the AspNetCore ruleset ***
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
+++ b/dotnet-roslyn/config/Audacia.CodeAnalysis/CHANGELOG.md
@@ -1,5 +1,15 @@
 ﻿# Changelog
 
+## 2.0.1 - 2026-07-16
+
+### Added
+
+- No new functionality added
+
+### Changed
+
+- Suppressed VSTHRD200 as functionality is covered by RCS1046 and ACL1005
+
 ## 2.0.0 - 2026-06-15
 
 ### Added

--- a/dotnet-roslyn/config/Directory.Build.props
+++ b/dotnet-roslyn/config/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Version changed and CHANGELOG updated
- ✔ New version set in the project file(s) `.csproj` or `Directory.Build.props` and version documented in the CHANGELOG

### Code ready for review
- ✔ Code compiles, all tests pass, no debug/console statements or commented out code left in

### Unit tests added/updated
- ❎ No code changed

### README or other documentation updated
- ❎ Changes do not require documentation

### Dependency licenses
- ❎ No new/upgraded dependencies

### Work item linked
- ❎ No work item exists and none is needed